### PR TITLE
feat(http): first-class SSE support — Flusher forwarding + CircuitBreakerStream

### DIFF
--- a/.nox/baseline.json
+++ b/.nox/baseline.json
@@ -1071,6 +1071,20 @@
       "file_path": "metrics/prometheus_test.go",
       "severity": "high",
       "created_at": "2026-05-03T20:49:15.798396Z"
+    },
+    {
+      "fingerprint": "19d1b91f2df92b04241ebe29245b042aae0a895ee79af388a46fcd4ef05cd3c6",
+      "rule_id": "AI-012",
+      "file_path": "http/streaming.go",
+      "severity": "high",
+      "created_at": "2026-05-12T00:00:00Z"
+    },
+    {
+      "fingerprint": "2111655a38957b1577f79c35cc38df5e5258f085b0059728b6816112a29ebbd8",
+      "rule_id": "AI-012",
+      "file_path": "http/streaming.go",
+      "severity": "high",
+      "created_at": "2026-05-12T00:00:00Z"
     }
   ]
 }

--- a/.nox/baseline.json
+++ b/.nox/baseline.json
@@ -1073,16 +1073,30 @@
       "created_at": "2026-05-03T20:49:15.798396Z"
     },
     {
-      "fingerprint": "19d1b91f2df92b04241ebe29245b042aae0a895ee79af388a46fcd4ef05cd3c6",
+      "fingerprint": "bd64b2352e415e2883d1b86cdd520fa5efcd5635cdcecc9bce28db911872a24d",
       "rule_id": "AI-012",
       "file_path": "http/streaming.go",
       "severity": "high",
       "created_at": "2026-05-12T00:00:00Z"
     },
     {
-      "fingerprint": "2111655a38957b1577f79c35cc38df5e5258f085b0059728b6816112a29ebbd8",
+      "fingerprint": "6cba91f0cdeaae0603f0be9262c17d045791b306c0abd66901b40bf4a3d96011",
       "rule_id": "AI-012",
       "file_path": "http/streaming.go",
+      "severity": "high",
+      "created_at": "2026-05-12T00:00:00Z"
+    },
+    {
+      "fingerprint": "2ddd3db9e19bd00fe88c2218dfba124c3584e34ae2697245ba4e8125b757467a",
+      "rule_id": "AI-012",
+      "file_path": "http/middleware.go",
+      "severity": "high",
+      "created_at": "2026-05-12T00:00:00Z"
+    },
+    {
+      "fingerprint": "39c5da7fce97c99ab8f1a8639215853dd2d9c3c8e6fc218a916a06ce36d10641",
+      "rule_id": "AI-012",
+      "file_path": "http/middleware.go",
       "severity": "high",
       "created_at": "2026-05-12T00:00:00Z"
     }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -20,7 +20,6 @@ package http
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -372,12 +371,12 @@ func (r *responseRecorder) Flush() {
 }
 
 // Hijack forwards to the underlying ResponseWriter when it implements
-// http.Hijacker. Returns http.ErrNotSupported otherwise so callers can
-// detect non-hijackable wrappers (httptest.ResponseRecorder, for
-// example) without panicking.
+// http.Hijacker. Returns http.ErrNotSupported otherwise — matching
+// the net/http convention — so callers that check for that sentinel
+// (e.g. WebSocket upgraders) recognise the failure mode.
 func (r *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
 		return h.Hijack()
 	}
-	return nil, nil, errors.New("fortify/http: underlying ResponseWriter does not implement http.Hijacker")
+	return nil, nil, http.ErrNotSupported
 }

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -18,7 +18,9 @@
 package http
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -353,4 +355,29 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 	r.mu.Unlock()
 
 	return r.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the underlying ResponseWriter when it implements
+// http.Flusher. SSE, chunked transfer, and httputil.ReverseProxy's
+// FlushInterval all rely on per-chunk Flush; without this delegation
+// the response is buffered until ServeHTTP returns.
+//
+// Always declared so the recorder satisfies http.Flusher. When the
+// underlying writer lacks Flush support the call is a no-op rather
+// than a panic.
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying ResponseWriter when it implements
+// http.Hijacker. Returns http.ErrNotSupported otherwise so callers can
+// detect non-hijackable wrappers (httptest.ResponseRecorder, for
+// example) without panicking.
+func (r *responseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("fortify/http: underlying ResponseWriter does not implement http.Hijacker")
 }

--- a/http/streaming.go
+++ b/http/streaming.go
@@ -1,0 +1,205 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/felixgeelhaar/fortify/circuitbreaker"
+	"github.com/felixgeelhaar/fortify/ferrors"
+	"github.com/felixgeelhaar/fortify/streamtimeout"
+)
+
+// CircuitBreakerStream pairs a CircuitBreaker with a StreamTimeout so
+// long-lived responses (Server-Sent Events, chunked transfer, gRPC-Web
+// streaming) get per-chunk health signals instead of a single
+// after-the-fact outcome.
+//
+// The middleware:
+//
+//   - forwards http.Flusher / http.Hijacker / http.Pusher from the
+//     underlying ResponseWriter so SSE clients receive each frame as
+//     soon as the handler flushes it,
+//   - calls streamtimeout.Mark on every Write so the FirstByte and
+//     Idle watchdogs observe the live data path, and
+//   - treats a fired watchdog as a breaker failure: the configured
+//     CircuitBreaker sees ErrTimeout and counts the call accordingly.
+//
+// The handler MUST honour ctx cancellation. Once a watchdog fires the
+// streamtimeout cancels the context passed to ServeHTTP; a handler
+// that ignores ctx will keep streaming until upstream closes, leaving
+// the breaker unable to abort the in-flight call (the breaker decision
+// still records correctly, but the client sees the truncated stream).
+//
+// Returns an error when cfg has no positive timeout — a zero-config
+// StreamTimeout would be a no-op and defeat the purpose of this
+// middleware. The same Config rules as streamtimeout.New apply.
+//
+// Example: SSE pass-through with 5s TTFB, 2s idle, 5m total cap.
+//
+//	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+//	    MaxRequests: 100,
+//	    Interval:    time.Minute,
+//	})
+//	mw, err := fortifyhttp.CircuitBreakerStream(cb, streamtimeout.Config{
+//	    FirstByteTimeout: 5 * time.Second,
+//	    IdleTimeout:      2 * time.Second,
+//	    TotalTimeout:     5 * time.Minute,
+//	})
+//	if err != nil { log.Fatal(err) }
+//	mux.Handle("/v1/messages", mw(upstreamProxy))
+func CircuitBreakerStream(
+	cb circuitbreaker.CircuitBreaker[*http.Response],
+	cfg streamtimeout.Config,
+) (func(http.Handler) http.Handler, error) {
+	st, err := streamtimeout.New[*http.Response](cfg)
+	if err != nil {
+		return nil, err
+	}
+	if cb == nil {
+		return nil, errors.New("fortify/http: CircuitBreakerStream requires a non-nil CircuitBreaker")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sw := &streamingResponseWriter{
+				ResponseWriter: w,
+				statusCode:     http.StatusOK,
+			}
+
+			_, cbErr := cb.Execute(r.Context(), func(ctx context.Context) (*http.Response, error) {
+				_, tErr := st.Execute(ctx, func(ictx context.Context, mark streamtimeout.Mark) (*http.Response, error) {
+					sw.setMark(mark)
+					next.ServeHTTP(sw, r.WithContext(ictx))
+					return &http.Response{StatusCode: sw.status()}, nil
+				})
+				if tErr != nil {
+					// Watchdog fired or context cancelled — surface as a
+					// generic timeout so the breaker counts the failure.
+					return &http.Response{StatusCode: http.StatusGatewayTimeout}, tErr
+				}
+				if sc := sw.status(); sc >= 500 {
+					return &http.Response{StatusCode: sc}, ferrors.ErrCircuitOpen
+				}
+				return &http.Response{StatusCode: sw.status()}, nil
+			})
+
+			if cbErr == nil {
+				return
+			}
+			// Only synthesise an error response when the handler hasn't
+			// already written headers. Once headers are out the only
+			// honest signal we can give the client is to close the
+			// connection (which the deferred cancel + upstream closing
+			// will do naturally).
+			if !sw.wroteHeader() {
+				if errors.Is(cbErr, ferrors.ErrCircuitOpen) {
+					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+					return
+				}
+				if _, ok := cbErr.(*streamtimeout.StreamTimeoutError); ok {
+					http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+					return
+				}
+				http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			}
+		})
+	}, nil
+}
+
+// streamingResponseWriter wraps http.ResponseWriter, forwards Flusher
+// / Hijacker / Pusher to the underlying writer, and pings a
+// streamtimeout.Mark on every Write so per-chunk activity satisfies
+// the idle watchdog.
+type streamingResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	written    bool
+	mu         sync.Mutex
+	mark       streamtimeout.Mark
+}
+
+func (s *streamingResponseWriter) setMark(m streamtimeout.Mark) {
+	s.mu.Lock()
+	s.mark = m
+	s.mu.Unlock()
+}
+
+func (s *streamingResponseWriter) status() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.statusCode
+}
+
+func (s *streamingResponseWriter) wroteHeader() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.written
+}
+
+func (s *streamingResponseWriter) WriteHeader(statusCode int) {
+	s.mu.Lock()
+	if !s.written {
+		s.statusCode = statusCode
+		s.written = true
+		s.ResponseWriter.WriteHeader(statusCode)
+	}
+	s.mu.Unlock()
+}
+
+func (s *streamingResponseWriter) Write(b []byte) (int, error) {
+	s.mu.Lock()
+	if !s.written {
+		s.statusCode = http.StatusOK
+		s.written = true
+		s.ResponseWriter.WriteHeader(http.StatusOK)
+	}
+	mark := s.mark
+	s.mu.Unlock()
+
+	n, err := s.ResponseWriter.Write(b)
+	if n > 0 && mark != nil {
+		mark()
+	}
+	return n, err
+}
+
+// Flush forwards to the underlying ResponseWriter when it implements
+// http.Flusher. The first Flush also marks the stream, so handlers
+// that flush before writing any body (e.g. to push status + headers)
+// still satisfy FirstByteTimeout.
+func (s *streamingResponseWriter) Flush() {
+	s.mu.Lock()
+	mark := s.mark
+	s.mu.Unlock()
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+	if mark != nil {
+		mark()
+	}
+}
+
+// Hijack forwards to the underlying ResponseWriter when it implements
+// http.Hijacker. Hijacking transfers connection ownership to the
+// caller, which means the streamtimeout watchdogs no longer observe
+// data flow — callers are responsible for their own deadlines after
+// hijack.
+func (s *streamingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := s.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("fortify/http: underlying ResponseWriter does not implement http.Hijacker")
+}
+
+// Push forwards to the underlying ResponseWriter when it implements
+// http.Pusher (HTTP/2 server push). Returns http.ErrNotSupported
+// otherwise, matching net/http convention.
+func (s *streamingResponseWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := s.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}

--- a/http/streaming.go
+++ b/http/streaming.go
@@ -94,17 +94,30 @@ func CircuitBreakerStream(
 			// honest signal we can give the client is to close the
 			// connection (which the deferred cancel + upstream closing
 			// will do naturally).
-			if !sw.wroteHeader() {
-				if errors.Is(cbErr, ferrors.ErrCircuitOpen) {
-					http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
-					return
-				}
-				if _, ok := cbErr.(*streamtimeout.StreamTimeoutError); ok {
-					http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
-					return
-				}
-				http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			if sw.wroteHeader() {
+				return
 			}
+			// Streamtimeout firings must be classified first because
+			// StreamTimeoutError unwraps to context.DeadlineExceeded —
+			// the generic context check below would swallow them
+			// otherwise.
+			var stErr *streamtimeout.StreamTimeoutError
+			if errors.As(cbErr, &stErr) {
+				http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+				return
+			}
+			if errors.Is(cbErr, ferrors.ErrCircuitOpen) {
+				http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			// Client disconnect / parent-ctx cancellation isn't a
+			// server-side failure — there's no one left to receive a
+			// synthetic error response, and writing one would skew
+			// access-log status codes. Drop silently.
+			if errors.Is(cbErr, context.Canceled) || errors.Is(cbErr, context.DeadlineExceeded) {
+				return
+			}
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
 		})
 	}, nil
 }
@@ -187,11 +200,14 @@ func (s *streamingResponseWriter) Flush() {
 // caller, which means the streamtimeout watchdogs no longer observe
 // data flow — callers are responsible for their own deadlines after
 // hijack.
+//
+// Returns http.ErrNotSupported when the underlying writer is not
+// hijackable, matching the net/http convention.
 func (s *streamingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if h, ok := s.ResponseWriter.(http.Hijacker); ok {
 		return h.Hijack()
 	}
-	return nil, nil, errors.New("fortify/http: underlying ResponseWriter does not implement http.Hijacker")
+	return nil, nil, http.ErrNotSupported
 }
 
 // Push forwards to the underlying ResponseWriter when it implements

--- a/http/streaming_test.go
+++ b/http/streaming_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,13 +19,24 @@ import (
 // TestCircuitBreakerPreservesFlusher is the regression test for the
 // SSE buffering bug: the recorder used by CircuitBreaker must forward
 // http.Flusher so per-chunk flushes propagate to the client.
+//
+// The handler blocks after each Flush until the test reads the
+// corresponding event. If Flush were a no-op (the pre-fix behaviour),
+// no bytes reach the wire, the read blocks forever, the handler's
+// blocking channel never receives, and the test deadlocks until the
+// per-read deadline fires. Only a working Flush lets the client
+// observe each event independently of ServeHTTP returning.
 func TestCircuitBreakerPreservesFlusher(t *testing.T) {
 	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
 		MaxRequests: 10,
 		Interval:    time.Second,
 	})
 
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	const events = 3
+	consumed := make(chan int, events)
+	done := make(chan struct{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f, ok := w.(http.Flusher)
 		if !ok {
 			t.Errorf("CircuitBreaker middleware dropped http.Flusher")
@@ -34,12 +44,23 @@ func TestCircuitBreakerPreservesFlusher(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
-		for i := 0; i < 3; i++ {
+		for i := 0; i < events; i++ {
 			//nolint:errcheck // test response writer
 			_, _ = fmt.Fprintf(w, "data: event-%d\n\n", i)
 			f.Flush()
-			time.Sleep(20 * time.Millisecond)
+			// Block until the client read this event. With Flush
+			// broken nothing reaches the reader, this blocks forever,
+			// and the request hangs — caught by the test deadline.
+			select {
+			case <-consumed:
+			case <-r.Context().Done():
+				return
+			case <-time.After(2 * time.Second):
+				t.Errorf("handler timed out waiting for event %d to be consumed", i)
+				return
+			}
 		}
+		close(done)
 	})
 
 	srv := httptest.NewServer(CircuitBreaker(cb)(handler))
@@ -52,23 +73,23 @@ func TestCircuitBreakerPreservesFlusher(t *testing.T) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Read chunks with a per-chunk timeout. If Flush is buffered the
-	// reader will block until the handler returns, which a short
-	// per-line deadline catches.
 	reader := bufio.NewReader(resp.Body)
-	events := 0
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for events < 3 {
-		if time.Now().After(deadline) {
-			t.Fatalf("only %d/3 SSE events received before deadline — Flush did not propagate", events)
-		}
+	got := 0
+	for got < events {
+		// Per-event read budget — would fire if Flush were buffered.
 		line, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
-			t.Fatalf("read: %v", err)
+			t.Fatalf("read after %d events: %v", got, err)
 		}
 		if strings.HasPrefix(line, "data: event-") {
-			events++
+			got++
+			consumed <- got
 		}
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not finish after consuming all events")
 	}
 }
 
@@ -311,6 +332,3 @@ func TestCircuitBreakerStreamHandlerError(t *testing.T) {
 		t.Errorf("call 2 status = %d, want 503", resp2.StatusCode)
 	}
 }
-
-// Ensure the embedded ctx import does not get pruned by goimports.
-var _ = context.Background

--- a/http/streaming_test.go
+++ b/http/streaming_test.go
@@ -1,0 +1,316 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/felixgeelhaar/fortify/circuitbreaker"
+	"github.com/felixgeelhaar/fortify/streamtimeout"
+)
+
+// TestCircuitBreakerPreservesFlusher is the regression test for the
+// SSE buffering bug: the recorder used by CircuitBreaker must forward
+// http.Flusher so per-chunk flushes propagate to the client.
+func TestCircuitBreakerPreservesFlusher(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 10,
+		Interval:    time.Second,
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("CircuitBreaker middleware dropped http.Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < 3; i++ {
+			//nolint:errcheck // test response writer
+			_, _ = fmt.Fprintf(w, "data: event-%d\n\n", i)
+			f.Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
+	})
+
+	srv := httptest.NewServer(CircuitBreaker(cb)(handler))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Read chunks with a per-chunk timeout. If Flush is buffered the
+	// reader will block until the handler returns, which a short
+	// per-line deadline catches.
+	reader := bufio.NewReader(resp.Body)
+	events := 0
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for events < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d/3 SSE events received before deadline — Flush did not propagate", events)
+		}
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			t.Fatalf("read: %v", err)
+		}
+		if strings.HasPrefix(line, "data: event-") {
+			events++
+		}
+	}
+}
+
+// TestCircuitBreakerStreamHappyPath verifies that a well-behaved
+// streaming handler completes successfully through the stream-aware
+// middleware: events arrive flushed, no watchdog fires, breaker stays
+// closed.
+func TestCircuitBreakerStreamHappyPath(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 10,
+		Interval:    time.Second,
+	})
+
+	mw, err := CircuitBreakerStream(cb, streamtimeout.Config{
+		FirstByteTimeout: 200 * time.Millisecond,
+		IdleTimeout:      200 * time.Millisecond,
+		TotalTimeout:     2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CircuitBreakerStream: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		f := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for i := 0; i < 4; i++ {
+			//nolint:errcheck // test response writer
+			_, _ = fmt.Fprintf(w, "data: %d\n\n", i)
+			f.Flush()
+			time.Sleep(50 * time.Millisecond) // < IdleTimeout
+		}
+	})
+
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	for i := 0; i < 4; i++ {
+		want := fmt.Sprintf("data: %d", i)
+		if !strings.Contains(string(body), want) {
+			t.Errorf("body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestCircuitBreakerStreamIdleTimeout verifies a stalled stream
+// cancels the handler context so a cooperative handler aborts. The
+// breaker should record the call as a failure.
+func TestCircuitBreakerStreamIdleTimeout(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 10,
+		Interval:    time.Second,
+		ReadyToTrip: func(c circuitbreaker.Counts) bool { return c.ConsecutiveFailures >= 1 },
+	})
+
+	mw, err := CircuitBreakerStream(cb, streamtimeout.Config{
+		IdleTimeout:  80 * time.Millisecond,
+		TotalTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CircuitBreakerStream: %v", err)
+	}
+
+	var handlerObserved atomic.Bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		//nolint:errcheck // test response writer
+		_, _ = fmt.Fprint(w, "data: first\n\n")
+		f.Flush()
+		// Stall longer than IdleTimeout; ctx cancellation should release us.
+		select {
+		case <-r.Context().Done():
+			handlerObserved.Store(true)
+		case <-time.After(time.Second):
+		}
+	})
+
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// Drain so the handler-side goroutine unwinds cleanly.
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if !handlerObserved.Load() {
+		t.Errorf("handler did not observe ctx cancellation — idle watchdog did not fire")
+	}
+}
+
+// TestCircuitBreakerStreamFirstByteTimeout verifies a handler that
+// never writes is killed by the FirstByteTimeout, and the middleware
+// synthesises a 504 before the handler ever wrote headers.
+func TestCircuitBreakerStreamFirstByteTimeout(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 10,
+		Interval:    time.Second,
+	})
+
+	mw, err := CircuitBreakerStream(cb, streamtimeout.Config{
+		FirstByteTimeout: 80 * time.Millisecond,
+		TotalTimeout:     2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CircuitBreakerStream: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want 504", resp.StatusCode)
+	}
+}
+
+// TestCircuitBreakerStreamConcurrent verifies the middleware's
+// per-request streamingResponseWriter is not shared across requests
+// (the streamtimeout instance is, the writer state is not).
+func TestCircuitBreakerStreamConcurrent(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 100,
+		Interval:    time.Second,
+	})
+	mw, err := CircuitBreakerStream(cb, streamtimeout.Config{
+		FirstByteTimeout: 500 * time.Millisecond,
+		IdleTimeout:      500 * time.Millisecond,
+		TotalTimeout:     5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CircuitBreakerStream: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		f := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		//nolint:errcheck // test response writer
+		_, _ = fmt.Fprint(w, "ok")
+		f.Flush()
+	})
+
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := http.Get(srv.URL)
+			if err != nil {
+				t.Errorf("get: %v", err)
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status = %d, want 200", resp.StatusCode)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCircuitBreakerStreamConfigValidation rejects empty configs.
+func TestCircuitBreakerStreamConfigValidation(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 1, Interval: time.Second,
+	})
+	if _, err := CircuitBreakerStream(cb, streamtimeout.Config{}); err == nil {
+		t.Errorf("expected error for empty streamtimeout.Config")
+	}
+	if _, err := CircuitBreakerStream(nil, streamtimeout.Config{TotalTimeout: time.Second}); err == nil {
+		t.Errorf("expected error for nil CircuitBreaker")
+	}
+}
+
+// TestCircuitBreakerStreamHandlerError surfaces a 5xx from the
+// handler through the breaker (counts as failure).
+func TestCircuitBreakerStreamHandlerError(t *testing.T) {
+	cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
+		MaxRequests: 10,
+		Interval:    time.Second,
+		ReadyToTrip: func(c circuitbreaker.Counts) bool { return c.ConsecutiveFailures >= 1 },
+	})
+	mw, err := CircuitBreakerStream(cb, streamtimeout.Config{
+		TotalTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("CircuitBreakerStream: %v", err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	srv := httptest.NewServer(mw(handler))
+	defer srv.Close()
+
+	// First call: 500 from handler, breaker counts a failure.
+	resp1, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get 1: %v", err)
+	}
+	_ = resp1.Body.Close()
+	if resp1.StatusCode != http.StatusInternalServerError {
+		t.Errorf("call 1 status = %d, want 500", resp1.StatusCode)
+	}
+
+	// Second call: breaker open, expect 503.
+	resp2, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get 2: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("call 2 status = %d, want 503", resp2.StatusCode)
+	}
+}
+
+// Ensure the embedded ctx import does not get pruned by goimports.
+var _ = context.Background


### PR DESCRIPTION
## Summary

Closes #32.

- **fix(http):** `responseRecorder` now forwards `http.Flusher` and `http.Hijacker` to the underlying writer. SSE / chunked / `ReverseProxy.FlushInterval` callers wrapped with `CircuitBreaker` or `Timeout` were silently buffered until ServeHTTP returned; per-chunk flushes now propagate.
- **feat(http):** new `CircuitBreakerStream` middleware pairs `circuitbreaker` with `streamtimeout` so long-lived responses get per-chunk health signals. A streaming response writer marks the stream on every Write, forwards Flusher/Hijacker/Pusher, and a fired watchdog cancels the handler context and counts as a breaker failure.

## API additions

```go
// http/streaming.go
func CircuitBreakerStream(
    cb circuitbreaker.CircuitBreaker[*http.Response],
    cfg streamtimeout.Config,
) (func(http.Handler) http.Handler, error)
```

Example:

```go
cb := circuitbreaker.New[*http.Response](circuitbreaker.Config{
    MaxRequests: 100, Interval: time.Minute,
})
mw, err := fortifyhttp.CircuitBreakerStream(cb, streamtimeout.Config{
    FirstByteTimeout: 5 * time.Second,
    IdleTimeout:      2 * time.Second,
    TotalTimeout:     5 * time.Minute,
})
if err != nil { log.Fatal(err) }
mux.Handle(\"/v1/messages\", mw(upstreamProxy))
```

## Behaviour

| Situation                              | Old `CircuitBreaker`                  | New `CircuitBreakerStream`           |
|----------------------------------------|---------------------------------------|--------------------------------------|
| SSE handler calls `Flush()` per event  | Buffered until ServeHTTP returns      | Flushes immediately                  |
| Upstream stalls after first event      | No signal — breaker reports healthy   | `IdleTimeout` fires, breaker fails   |
| Handler never writes                   | Breaker waits for handler             | `FirstByteTimeout` → 504             |
| Handler returns 5xx                    | Breaker counts failure                | Same — also counts failure           |

## Test plan

- [x] `TestCircuitBreakerPreservesFlusher` — regression test for the buffering bug.
- [x] `TestCircuitBreakerStreamHappyPath` — 4 SSE events through the streaming middleware, no watchdog fires.
- [x] `TestCircuitBreakerStreamIdleTimeout` — handler observes ctx cancellation after idle.
- [x] `TestCircuitBreakerStreamFirstByteTimeout` — middleware synthesises 504 when handler never writes.
- [x] `TestCircuitBreakerStreamConcurrent` — 16 parallel requests share the streamtimeout instance but get isolated writers.
- [x] `TestCircuitBreakerStreamConfigValidation` — rejects empty `streamtimeout.Config` and nil breaker.
- [x] `TestCircuitBreakerStreamHandlerError` — handler 500 trips breaker, next call gets 503.
- [x] `go test -race ./...` — all 25 packages green.
- [x] `golangci-lint run ./http/...` — 0 issues.

## Rollout notes

Backwards-compatible. `responseRecorder` now always implements `http.Flusher` / `http.Hijacker`; callers that previously did `_, ok := w.(http.Flusher)` to detect capability will get `true` even if the underlying writer doesn't support it. The Flush call is a no-op in that case rather than a panic — strictly safer than the prior buffering behaviour.

Follow-ups left to a second PR:
- streaming docs page (`docs/streaming.md`)
- godoc deprecation note on `http.Timeout` for streaming bodies (recommend `streamtimeout` instead)