### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,22 +16,9 @@ linters:
     - unparam
     - gocritic
     - gocyclo
-    - gosec
     - dupl
-  settings:
-    gosec:
-      # G115 fires on every int -> int32 narrowing, even when source is
-      # config-bounded (clamped in setDefaults). Adaptive limiter uses
-      # atomic.Int32 mirrors as a deliberate hot-path design.
-      excludes:
-        - G115
   exclusions:
     rules:
-      # Tests legitimately use math/rand (deterministic fixtures, fuzz
-      # seeds). G404 weak-RNG does not apply to test code. (Org bar.)
-      - path: _test\.go
-        linters:
-          - gosec
       # Preset chains intentionally share structure (CB -> Retry -> Timeout)
       # across HTTPClient / DatabaseQuery / RPCDownstream. Tuning differs;
       # extracting a shared helper would obscure each preset's intent.

--- a/bulkhead/bulkhead_test.go
+++ b/bulkhead/bulkhead_test.go
@@ -44,7 +44,7 @@ func TestBulkheadExecute(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				//nolint:errcheck,gosec // intentionally ignoring error in test
+				//nolint:errcheck // intentionally ignoring error in test
 				_, _ = bh.Execute(ctx, func(ctx context.Context) (int, error) {
 					current := executing.Add(1)
 					defer executing.Add(-1)
@@ -82,7 +82,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// Start first request (fills bulkhead)
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in goroutine
+			//nolint:errcheck // intentionally ignoring error in goroutine
 			bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				started <- true
 				<-done
@@ -117,7 +117,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// First request (fills bulkhead)
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			result, _ := bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				started <- true
 				time.Sleep(50 * time.Millisecond)
@@ -132,7 +132,7 @@ func TestBulkheadExecute(t *testing.T) {
 		for i := 2; i <= 3; i++ {
 			val := i
 			go func() {
-				//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+				//nolint:errcheck // intentionally ignoring error in test goroutine
 				result, _ := bh.Execute(ctx, func(ctx context.Context) (int, error) {
 					return val, nil
 				})
@@ -164,7 +164,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// Fill bulkhead
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				started <- true
 				<-release
@@ -176,7 +176,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// Fill queue
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				return 2, nil
 			})
@@ -208,7 +208,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// Fill bulkhead
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			bh.Execute(context.Background(), func(ctx context.Context) (int, error) {
 				started <- true
 				<-release
@@ -245,7 +245,7 @@ func TestBulkheadExecute(t *testing.T) {
 
 		// Fill bulkhead with long-running operation
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				started <- true
 				time.Sleep(200 * time.Millisecond)
@@ -284,7 +284,7 @@ func TestBulkheadCallback(t *testing.T) {
 
 		// Fill bulkhead
 		go func() {
-			//nolint:errcheck,gosec // intentionally ignoring error in test goroutine
+			//nolint:errcheck // intentionally ignoring error in test goroutine
 			bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				started <- true
 				<-done
@@ -295,7 +295,7 @@ func TestBulkheadCallback(t *testing.T) {
 		<-started
 
 		// This should be rejected
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		bh.Execute(ctx, func(ctx context.Context) (int, error) {
 			return 2, nil
 		})
@@ -362,7 +362,7 @@ func TestBulkheadClose(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			//nolint:errcheck,gosec // intentionally ignoring error in test
+			//nolint:errcheck // intentionally ignoring error in test
 			_, _ = bh.Execute(ctx, func(ctx context.Context) (int, error) {
 				time.Sleep(50 * time.Millisecond)
 				return 1, nil

--- a/bulkhead/example_test.go
+++ b/bulkhead/example_test.go
@@ -124,7 +124,7 @@ func Example_queueTimeout() {
 
 	// First request will execute
 	go func() {
-		//nolint:errcheck,gosec // intentionally ignoring error in example
+		//nolint:errcheck // intentionally ignoring error in example
 		bh.Execute(context.Background(), func(ctx context.Context) (string, error) {
 			time.Sleep(time.Millisecond * 500)
 			return "long operation", nil
@@ -159,7 +159,7 @@ func Example_rejectionCallback() {
 
 	// First request will execute
 	go func() {
-		//nolint:errcheck,gosec // intentionally ignoring error in example goroutine
+		//nolint:errcheck // intentionally ignoring error in example goroutine
 		bh.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			time.Sleep(time.Millisecond * 100)
 			return 1, nil
@@ -169,7 +169,7 @@ func Example_rejectionCallback() {
 	time.Sleep(time.Millisecond * 10) // Let first request start
 
 	// Second request will be rejected
-	//nolint:errcheck,gosec // intentionally ignoring error in example
+	//nolint:errcheck // intentionally ignoring error in example
 	bh.Execute(context.Background(), func(ctx context.Context) (int, error) {
 		return 2, nil
 	})
@@ -229,7 +229,7 @@ func Example_resourceIsolation() {
 	})
 
 	// Database operation
-	//nolint:errcheck,gosec // intentionally ignoring error in test
+	//nolint:errcheck // intentionally ignoring error in test
 	dbResult, _ := dbBulkhead.Execute(context.Background(), func(ctx context.Context) (string, error) {
 		// Simulate DB query
 		return "db result", nil
@@ -335,12 +335,12 @@ func Example_microserviceIsolation() {
 	})
 
 	// If order service is slow/failing, it won't affect user service calls
-	//nolint:errcheck,gosec // intentionally ignoring error in test
+	//nolint:errcheck // intentionally ignoring error in test
 	userResult, _ := userServiceBulkhead.Execute(context.Background(), func(ctx context.Context) (string, error) {
 		return "user data", nil
 	})
 
-	//nolint:errcheck,gosec // intentionally ignoring error in test
+	//nolint:errcheck // intentionally ignoring error in test
 	orderResult, _ := orderServiceBulkhead.Execute(context.Background(), func(ctx context.Context) (string, error) {
 		return "order data", nil
 	})

--- a/circuitbreaker/breaker_test.go
+++ b/circuitbreaker/breaker_test.go
@@ -58,7 +58,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 		})
 
 		// Trigger failure to open circuit
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -90,7 +90,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 		})
 
 		// Open the circuit
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -104,7 +104,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 
 		// Next request should attempt execution (half-open)
 		executed := false
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			executed = true
 			return 42, nil
@@ -126,7 +126,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 		})
 
 		// Open the circuit
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -136,7 +136,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 
 		// Successful requests in half-open
 		for i := 0; i < 2; i++ {
-			//nolint:errcheck,gosec // intentionally ignoring error in test
+			//nolint:errcheck // intentionally ignoring error in test
 			cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 				return 42, nil
 			})
@@ -158,7 +158,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 		})
 
 		// Open the circuit
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -167,7 +167,7 @@ func TestCircuitBreakerStates(t *testing.T) {
 		time.Sleep(60 * time.Millisecond)
 
 		// Fail in half-open state
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -243,7 +243,7 @@ func TestCircuitBreakerReset(t *testing.T) {
 	})
 
 	// Open the circuit
-	//nolint:errcheck,gosec // intentionally ignoring error in test
+	//nolint:errcheck // intentionally ignoring error in test
 	cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 		return 0, errors.New("failure")
 	})
@@ -295,7 +295,7 @@ func TestCircuitBreakerCallbacks(t *testing.T) {
 		})
 
 		// Trigger state change from Closed to Open
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -320,7 +320,7 @@ func TestCircuitBreakerCounts(t *testing.T) {
 
 	// Successful requests
 	for i := 0; i < 3; i++ {
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 42, nil
 		})
@@ -328,7 +328,7 @@ func TestCircuitBreakerCounts(t *testing.T) {
 
 	// Failed requests
 	for i := 0; i < 2; i++ {
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		cb.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -348,13 +348,13 @@ func TestCircuitBreakerCounts(t *testing.T) {
 	})
 
 	for i := 0; i < 3; i++ {
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = testCB.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 42, nil
 		})
 	}
 	for i := 0; i < 2; i++ {
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = testCB.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})

--- a/examples/composition/main.go
+++ b/examples/composition/main.go
@@ -38,7 +38,6 @@ func (c *ExternalAPIClient) Call(ctx context.Context, requestID string) (*APIRes
 	}
 
 	// Simulate random failures
-	//nolint:gosec // G404: using math/rand intentionally for non-security simulation
 	if rand.Float64() < c.failureRate {
 		return nil, errors.New("external API error")
 	}
@@ -55,8 +54,7 @@ func main() {
 	// 30% failure rate, 100-500ms latency
 	apiClient := &ExternalAPIClient{
 		failureRate: 0.3,
-		//nolint:gosec // G404: using math/rand intentionally for simulation latency
-		latency: time.Millisecond * time.Duration(100+rand.Intn(400)),
+		latency:     time.Millisecond * time.Duration(100+rand.Intn(400)),
 	}
 
 	// Build a comprehensive resilience chain

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -47,14 +47,12 @@ func main() {
 	// Protected endpoint with all patterns
 	protectedHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Simulate occasional failures and slow responses
-		//nolint:gosec // G404: using math/rand intentionally for simulation
 		if rand.Intn(10) < 2 {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 
 		// Simulate variable response time
-		//nolint:gosec // G404: using math/rand intentionally for simulation
 		time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
 
 		w.WriteHeader(http.StatusOK)
@@ -76,7 +74,7 @@ func main() {
 		apiKey := r.Header.Get("X-API-Key")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		//nolint:errcheck,gosec // G705: text/plain response, XSS not applicable
+		//nolint:errcheck // G705: text/plain response, XSS not applicable
 		_, _ = fmt.Fprintf(w, "API accessed with key: %s at %s\n", apiKey, time.Now().Format(time.RFC3339))
 	})
 

--- a/ratelimit/limiter_test.go
+++ b/ratelimit/limiter_test.go
@@ -432,7 +432,7 @@ func TestMemoryStore(t *testing.T) {
 		ctx := context.Background()
 
 		// Create state
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test-key", func(s *BucketState) *BucketState {
 			return &BucketState{Tokens: 10, LastRefill: time.Now()}
 		})
@@ -641,7 +641,7 @@ func TestMemoryStoreGet(t *testing.T) {
 
 		// Create state
 		now := time.Now()
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test-key", func(s *BucketState) *BucketState {
 			return &BucketState{Tokens: 10, LastRefill: now}
 		})
@@ -677,7 +677,7 @@ func TestMemoryStoreClose(t *testing.T) {
 		ctx := context.Background()
 
 		// Create some state
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test-key", func(s *BucketState) *BucketState {
 			return &BucketState{Tokens: 10, LastRefill: time.Now()}
 		})
@@ -786,7 +786,7 @@ func TestMemoryStoreTTLCleanup(t *testing.T) {
 		ctx := context.Background()
 
 		// Create a key
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "stale-key", func(s *BucketState) *BucketState {
 			return &BucketState{Tokens: 10, LastRefill: time.Now()}
 		})
@@ -813,7 +813,7 @@ func TestMemoryStoreTTLCleanup(t *testing.T) {
 		ctx := context.Background()
 
 		// Create a key
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "active-key", func(s *BucketState) *BucketState {
 			return &BucketState{Tokens: 10, LastRefill: time.Now()}
 		})
@@ -821,7 +821,7 @@ func TestMemoryStoreTTLCleanup(t *testing.T) {
 		// Keep accessing the key to prevent expiry
 		for i := 0; i < 5; i++ {
 			time.Sleep(40 * time.Millisecond)
-			//nolint:errcheck,gosec // test setup
+			//nolint:errcheck // test setup
 			_, _ = store.AtomicUpdate(ctx, "active-key", func(s *BucketState) *BucketState {
 				return s
 			})
@@ -1093,7 +1093,7 @@ func TestMemoryStoreClear(t *testing.T) {
 
 		// Create multiple keys
 		for i := 0; i < 10; i++ {
-			//nolint:errcheck,gosec // test setup
+			//nolint:errcheck // test setup
 			_, _ = store.AtomicUpdate(ctx, fmt.Sprintf("key-%d", i), func(s *BucketState) *BucketState {
 				return &BucketState{Tokens: 10, LastRefill: time.Now()}
 			})
@@ -2001,7 +2001,7 @@ func TestRefillEdgeCases(t *testing.T) {
 
 		// Create initial state with a future timestamp
 		futureTime := time.Now().Add(time.Hour)
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test", func(s *BucketState) *BucketState {
 			return &BucketState{
 				Tokens:     5,
@@ -2062,7 +2062,7 @@ func TestRefillEdgeCases(t *testing.T) {
 
 		// Create state with very old timestamp (simulating system sleep/wake)
 		oldTime := time.Now().Add(-24 * time.Hour)
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test", func(s *BucketState) *BucketState {
 			return &BucketState{
 				Tokens:     0,
@@ -2132,7 +2132,7 @@ func TestRefillEdgeCases(t *testing.T) {
 		ctx := context.Background()
 
 		// Create state at burst limit
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test", func(s *BucketState) *BucketState {
 			return &BucketState{
 				Tokens:     10, // At burst limit
@@ -2192,7 +2192,7 @@ func TestRefillEdgeCases(t *testing.T) {
 
 		// Create state with old timestamp to simulate long system sleep
 		oldTime := time.Now().Add(-24 * time.Hour)
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test", func(s *BucketState) *BucketState {
 			return &BucketState{
 				Tokens:     0,
@@ -2237,7 +2237,7 @@ func TestRefillEdgeCases(t *testing.T) {
 		ctx := context.Background()
 
 		// Set up state just below burst
-		//nolint:errcheck,gosec // test setup
+		//nolint:errcheck // test setup
 		_, _ = store.AtomicUpdate(ctx, "test", func(s *BucketState) *BucketState {
 			return &BucketState{
 				Tokens:     9,

--- a/retry/backoff.go
+++ b/retry/backoff.go
@@ -78,7 +78,6 @@ func addJitter(delay time.Duration) time.Duration {
 	// math/rand/v2 has lock-free per-goroutine state, avoiding the global
 	// mutex contention of math/rand under parallel callers. Predictability
 	// is acceptable for retry jitter.
-	//nolint:gosec // G404: weak random is intentional and appropriate for retry jitter
 	jitterAmount := time.Duration(rand.Float64() * float64(delay) * 0.1)
 	return delay + jitterAmount
 }

--- a/retry/example_test.go
+++ b/retry/example_test.go
@@ -74,7 +74,7 @@ func Example_linearBackoff() {
 	})
 
 	attempt := 0
-	//nolint:errcheck,gosec // intentionally ignoring error in example
+	//nolint:errcheck // intentionally ignoring error in example
 	r.Execute(context.Background(), func(ctx context.Context) (string, error) {
 		attempt++
 		return "", fmt.Errorf("error %d", attempt)
@@ -256,7 +256,7 @@ func Example_jitter() {
 	})
 
 	attempt := 0
-	//nolint:errcheck,gosec // intentionally ignoring error in example
+	//nolint:errcheck // intentionally ignoring error in example
 	r.Execute(context.Background(), func(ctx context.Context) (string, error) {
 		attempt++
 		if attempt < 3 {

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -194,7 +194,7 @@ func TestRetryBackoff(t *testing.T) {
 		attempts := 0
 		start := time.Now()
 
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			attempts++
 			return 0, errors.New("failure")
@@ -220,7 +220,7 @@ func TestRetryBackoff(t *testing.T) {
 		attempts := 0
 		start := time.Now()
 
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			attempts++
 			return 0, errors.New("failure")
@@ -244,7 +244,7 @@ func TestRetryBackoff(t *testing.T) {
 		attempts := 0
 		start := time.Now()
 
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		_, _ = r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			attempts++
 			return 0, errors.New("failure")
@@ -269,7 +269,7 @@ func TestRetryBackoff(t *testing.T) {
 
 		start := time.Now()
 
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -296,7 +296,7 @@ func TestRetryCallbacks(t *testing.T) {
 			},
 		})
 
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})
@@ -324,7 +324,7 @@ func TestRetryWithJitter(t *testing.T) {
 	durations := make([]time.Duration, 3)
 	for i := 0; i < 3; i++ {
 		start := time.Now()
-		//nolint:errcheck,gosec // intentionally ignoring error in test
+		//nolint:errcheck // intentionally ignoring error in test
 		r.Execute(context.Background(), func(ctx context.Context) (int, error) {
 			return 0, errors.New("failure")
 		})

--- a/testing/chaos.go
+++ b/testing/chaos.go
@@ -14,7 +14,7 @@ import (
 	// 3. math/rand provides sufficient randomness for chaos engineering
 	// 4. crypto/rand would add unnecessary overhead to test utilities.
 	// 5. Predictable seeds can actually be useful for reproducing test scenarios.
-	"math/rand" //nolint:gosec // G404: weak random is intentional and appropriate for testing utilities
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -57,7 +57,6 @@ func (e *ErrorInjector) ShouldFail() bool {
 
 	// Weak random is appropriate here because this is a testing utility
 	// that simulates probabilistic failures for chaos engineering
-	//nolint:gosec // G404: weak random is intentional for testing
 	if rand.Float64() < prob {
 		e.failures.Add(1)
 		return true
@@ -146,7 +145,6 @@ func (l *LatencyInjector) Delay(ctx context.Context) error {
 	if maxDelay > minDelay {
 		// Weak random is appropriate here because this is a testing utility
 		// that simulates variable latency for chaos engineering
-		//nolint:gosec // G404: weak random is intentional for testing
 		delay = minDelay + time.Duration(rand.Int63n(int64(maxDelay-minDelay)))
 	}
 
@@ -230,7 +228,6 @@ func (t *TimeoutSimulator) Context(parent context.Context) (context.Context, con
 	// Decide if we should simulate timeout
 	// Weak random is appropriate here because this is a testing utility
 	// that simulates probabilistic timeouts for chaos engineering
-	//nolint:gosec // G404: weak random is intentional for testing
 	if rand.Float64() < prob {
 		t.timeouts.Add(1)
 		return context.WithTimeout(parent, timeout)

--- a/testing/performance.go
+++ b/testing/performance.go
@@ -139,7 +139,6 @@ func (pt *PerformanceTracker) AddBaseline(baseline PerformanceBaseline) {
 
 // LoadBaselines loads baselines from a JSON file.
 func (pt *PerformanceTracker) LoadBaselines(path string) error {
-	//nolint:gosec // G304: path is controlled by library caller, not user input
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read baselines: %w", err)
@@ -171,7 +170,6 @@ func (pt *PerformanceTracker) SaveBaselines(path string) error {
 
 	// Baseline files are performance reference data, not secrets
 	// Using 0o644 permissions allows team members to read baseline files
-	//nolint:gosec // G306: baseline file permissions intentionally set to 0o644 for team readability
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write baselines: %w", err)
 	}
@@ -226,7 +224,6 @@ func (pt *PerformanceTracker) LoadLatestReport() (*BenchmarkReport, error) {
 		return nil, fmt.Errorf("no benchmark reports found")
 	}
 
-	//nolint:gosec // G304: latestFile is constructed from trusted directory listing
 	data, err := os.ReadFile(latestFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read report: %w", err)


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `fortify` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 63 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.