### PR TITLE
feat: spec-aligned cost-budget API (WithCostBudget) + hardening

### DIFF
--- a/budget/budget.go
+++ b/budget/budget.go
@@ -12,6 +12,10 @@
 //   - USDMicros (1_000_000 = $1; integer to avoid float drift).
 //   - Calls (incremented automatically; Charge cannot affect it).
 //
+// Budgets may be capped indefinitely (manual Reset) or over a rolling
+// time window via Config.ResetAfter, which auto-clears the accumulated
+// cost once the window elapses.
+//
 // Sensitive payloads: budget never inspects the operation result or
 // error contents beyond what Charge returns. Charge must not return
 // content fields it does not want surfaced via OnExceeded.
@@ -32,7 +36,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // ErrBudgetExceeded is the sentinel returned (wrapped by *BudgetExceededError)
@@ -81,6 +87,14 @@ type Config[T any] struct {
 	// keep it short. Panics are recovered and logged via Logger.
 	OnExceeded func(consumed Cost)
 
+	// ResetAfter, when positive, enables a rolling time window: the
+	// accumulated cost (and any breach) is automatically cleared once this
+	// much wall-clock time has elapsed since the window opened. The window
+	// opens on the first Execute and reopens on each auto-reset. A
+	// non-positive value (the default) disables auto-reset; callers must
+	// then drive Reset manually.
+	ResetAfter time.Duration
+
 	// Logger receives diagnostic warnings (callback panics, breach
 	// notices). Nil disables internal logging.
 	Logger *slog.Logger
@@ -95,6 +109,16 @@ type Budget[T any] struct {
 	usdMicros atomic.Int64
 	calls     atomic.Int64
 	breached  atomic.Bool
+
+	// now is the clock source; overridable in tests for deterministic
+	// ResetAfter behaviour. Defaults to time.Now.
+	now func() time.Time
+
+	// windowMu guards the rolling-window bookkeeping for ResetAfter.
+	// It is only contended when ResetAfter is configured.
+	windowMu    sync.Mutex
+	windowStart time.Time
+	windowOpen  bool
 }
 
 // New constructs a Budget. Returns an error if Max is entirely zero
@@ -104,7 +128,7 @@ func New[T any](cfg Config[T]) (*Budget[T], error) {
 	if cfg.Max.Tokens <= 0 && cfg.Max.USDMicros <= 0 && cfg.Max.Calls <= 0 {
 		return nil, errors.New("budget.New: at least one Max field must be positive")
 	}
-	return &Budget[T]{cfg: cfg}, nil
+	return &Budget[T]{cfg: cfg, now: time.Now}, nil
 }
 
 // Execute runs fn, charges the resulting cost against the budget, and
@@ -116,6 +140,8 @@ func New[T any](cfg Config[T]) (*Budget[T], error) {
 // and *BudgetExceededError is returned immediately.
 func (b *Budget[T]) Execute(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
 	var zero T
+
+	b.maybeAutoReset()
 
 	if b.breached.Load() {
 		return zero, b.exceededError(b.snapshot())
@@ -157,8 +183,46 @@ func (b *Budget[T]) Consumed() Cost {
 }
 
 // Reset clears the accumulated cost and re-arms OnExceeded. Useful for
-// per-request budgets reused across handlers.
+// per-request budgets reused across handlers. Reset also closes any open
+// rolling window; the next Execute reopens it (for ResetAfter budgets).
 func (b *Budget[T]) Reset() {
+	b.tokens.Store(0)
+	b.usdMicros.Store(0)
+	b.calls.Store(0)
+	b.breached.Store(false)
+
+	if b.cfg.ResetAfter > 0 {
+		b.windowMu.Lock()
+		b.windowOpen = false
+		b.windowMu.Unlock()
+	}
+}
+
+// maybeAutoReset clears the accumulated cost when the configured ResetAfter
+// window has elapsed since it opened, then reopens the window. It is a no-op
+// when ResetAfter is non-positive. The window opens lazily on the first call.
+func (b *Budget[T]) maybeAutoReset() {
+	if b.cfg.ResetAfter <= 0 {
+		return
+	}
+
+	now := b.now()
+
+	b.windowMu.Lock()
+	if !b.windowOpen {
+		b.windowStart = now
+		b.windowOpen = true
+		b.windowMu.Unlock()
+		return
+	}
+	if now.Sub(b.windowStart) < b.cfg.ResetAfter {
+		b.windowMu.Unlock()
+		return
+	}
+	// Window elapsed: open a fresh one and clear the accumulated cost.
+	b.windowStart = now
+	b.windowMu.Unlock()
+
 	b.tokens.Store(0)
 	b.usdMicros.Store(0)
 	b.calls.Store(0)

--- a/budget/budget.go
+++ b/budget/budget.go
@@ -106,8 +106,18 @@ type Config[T any] struct {
 }
 
 // Budget enforces a Config across one or more Execute calls. Budgets
-// are safe for concurrent use; the aggregate cost is accumulated with
-// atomic operations.
+// are safe for concurrent use.
+//
+// Two storage modes share the same atomic counters:
+//
+//   - ResetAfter <= 0 (no window): the lock-free fast path. Counters are
+//     mutated with bare atomic operations; windowMu is never taken.
+//   - ResetAfter > 0 (rolling window): the windowed path. Every mutation of
+//     the counters — the auto-reset and the per-Execute charge/breach
+//     read-modify-write — is serialized under windowMu so a window reset can
+//     never interleave with (and clobber) a concurrent charge. The atomics are
+//     still the backing store, which keeps Consumed() and the breach fast-path
+//     check lock-free for readers.
 type Budget[T any] struct {
 	cfg       Config[T]
 	tokens    atomic.Int64
@@ -119,8 +129,9 @@ type Budget[T any] struct {
 	// ResetAfter behaviour. Defaults to time.Now.
 	now func() time.Time
 
-	// windowMu guards the rolling-window bookkeeping for ResetAfter.
-	// It is only contended when ResetAfter is configured.
+	// windowMu serializes the rolling-window bookkeeping AND the windowed
+	// charge/breach sequence for ResetAfter. It is only taken when ResetAfter
+	// is configured; the lock is otherwise uncontended (never acquired).
 	windowMu    sync.Mutex
 	windowStart time.Time
 	windowOpen  bool
@@ -148,9 +159,16 @@ func New[T any](cfg Config[T]) (*Budget[T], error) {
 // If the budget was already exceeded before this call, fn is not run
 // and *BudgetExceededError is returned immediately.
 func (b *Budget[T]) Execute(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
-	var zero T
+	if b.cfg.ResetAfter > 0 {
+		return b.executeWindowed(ctx, fn)
+	}
+	return b.executeLockFree(ctx, fn)
+}
 
-	b.maybeAutoReset()
+// executeLockFree is the no-window fast path (ResetAfter <= 0). It mutates the
+// atomic counters without ever taking windowMu.
+func (b *Budget[T]) executeLockFree(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
+	var zero T
 
 	if b.breached.Load() {
 		return zero, b.exceededError(b.snapshot())
@@ -184,6 +202,70 @@ func (b *Budget[T]) Execute(ctx context.Context, fn func(context.Context) (T, er
 	return result, err
 }
 
+// executeWindowed is the rolling-window path (ResetAfter > 0). The auto-reset
+// and the charge/breach read-modify-write are guarded by the same windowMu so a
+// window boundary can never interleave with a charge: a reset cannot clobber a
+// concurrent Add, and no reader inside the critical section observes a
+// half-reset state. fn itself runs OUTSIDE the lock so a slow operation does not
+// serialize the whole budget; only the cheap bookkeeping before and after fn is
+// guarded.
+func (b *Budget[T]) executeWindowed(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
+	var zero T
+
+	// Reset (if the window elapsed) and the pre-charge happen atomically.
+	b.windowMu.Lock()
+	b.autoResetLocked()
+
+	if b.breached.Load() {
+		err := b.exceededError(b.snapshot())
+		b.windowMu.Unlock()
+		return zero, err
+	}
+
+	calls := b.calls.Add(1)
+	if b.cfg.Max.Calls > 0 && calls > b.cfg.Max.Calls {
+		fireCost, fire := b.markBreachLocked()
+		err := b.exceededError(b.snapshot())
+		b.windowMu.Unlock()
+		if fire {
+			b.fireOnExceeded(fireCost)
+		}
+		return zero, err
+	}
+	b.windowMu.Unlock()
+
+	// Run the operation without holding the lock.
+	result, err := fn(ctx)
+
+	// Charge + breach evaluation atomically w.r.t. a concurrent reset.
+	b.windowMu.Lock()
+	if b.cfg.Charge != nil {
+		c := b.cfg.Charge(ctx, result, err)
+		if c.Tokens > 0 {
+			b.tokens.Add(c.Tokens)
+		}
+		if c.USDMicros > 0 {
+			b.usdMicros.Add(c.USDMicros)
+		}
+	}
+	consumed := b.snapshot()
+	over := b.over(consumed)
+	var fireCost Cost
+	var fire bool
+	if over {
+		fireCost, fire = b.markBreachLocked()
+	}
+	b.windowMu.Unlock()
+
+	if fire {
+		b.fireOnExceeded(fireCost)
+	}
+	if over {
+		return result, b.exceededError(consumed)
+	}
+	return result, err
+}
+
 // Consumed returns the current aggregate cost. Snapshot semantics: the
 // fields are read independently and so may not be perfectly consistent
 // under heavy concurrent contention, but each field is monotonic.
@@ -195,43 +277,49 @@ func (b *Budget[T]) Consumed() Cost {
 // per-request budgets reused across handlers. Reset also closes any open
 // rolling window; the next Execute reopens it (for ResetAfter budgets).
 func (b *Budget[T]) Reset() {
+	// For windowed budgets, clear the counters under windowMu so a manual Reset
+	// is atomic w.r.t. a concurrent windowed Execute (same invariant as the
+	// auto-reset). The no-window path stays lock-free.
+	if b.cfg.ResetAfter > 0 {
+		b.windowMu.Lock()
+		b.tokens.Store(0)
+		b.usdMicros.Store(0)
+		b.calls.Store(0)
+		b.breached.Store(false)
+		b.windowOpen = false
+		b.windowMu.Unlock()
+		return
+	}
+
 	b.tokens.Store(0)
 	b.usdMicros.Store(0)
 	b.calls.Store(0)
 	b.breached.Store(false)
-
-	if b.cfg.ResetAfter > 0 {
-		b.windowMu.Lock()
-		b.windowOpen = false
-		b.windowMu.Unlock()
-	}
 }
 
-// maybeAutoReset clears the accumulated cost when the configured ResetAfter
-// window has elapsed since it opened, then reopens the window. It is a no-op
-// when ResetAfter is non-positive. The window opens lazily on the first call.
-func (b *Budget[T]) maybeAutoReset() {
-	if b.cfg.ResetAfter <= 0 {
-		return
-	}
-
+// autoResetLocked clears the accumulated cost when the configured ResetAfter
+// window has elapsed since it opened, then reopens the window. The window opens
+// lazily on the first call. The window is wall-clock and ctx-independent: it is
+// driven solely by Config.Clock (or time.Now) and is unaffected by context
+// deadlines or cancellation.
+//
+// The caller MUST hold windowMu. The four atomic Stores happen inside this
+// critical section so a reset is atomic w.r.t. the windowed charge/breach
+// sequence in executeWindowed — no concurrent Add can be lost and no reader
+// inside the section observes a half-reset state.
+func (b *Budget[T]) autoResetLocked() {
 	now := b.now()
 
-	b.windowMu.Lock()
 	if !b.windowOpen {
 		b.windowStart = now
 		b.windowOpen = true
-		b.windowMu.Unlock()
 		return
 	}
 	if now.Sub(b.windowStart) < b.cfg.ResetAfter {
-		b.windowMu.Unlock()
 		return
 	}
-	// Window elapsed: open a fresh one and clear the accumulated cost.
+	// Window elapsed: open a fresh one and clear the accumulated cost atomically.
 	b.windowStart = now
-	b.windowMu.Unlock()
-
 	b.tokens.Store(0)
 	b.usdMicros.Store(0)
 	b.calls.Store(0)
@@ -259,11 +347,33 @@ func (b *Budget[T]) over(c Cost) bool {
 	return false
 }
 
+// markBreach flips the breached flag and fires OnExceeded once. Used on the
+// lock-free (no-window) path.
 func (b *Budget[T]) markBreach() {
 	if b.breached.CompareAndSwap(false, true) {
 		if b.cfg.OnExceeded != nil {
 			b.safeCallback(b.cfg.OnExceeded, b.snapshot())
 		}
+	}
+}
+
+// markBreachLocked flips the breached flag under windowMu but does NOT run the
+// OnExceeded callback while holding the lock (user code must not be able to
+// deadlock by re-entering Execute, nor stall every other goroutine on the
+// budget). If this call won the CAS and a callback is configured, it returns the
+// snapshot to fire; the caller must invoke fireOnExceeded after releasing the
+// lock. A zero/false return means nothing to fire.
+func (b *Budget[T]) markBreachLocked() (Cost, bool) {
+	if b.breached.CompareAndSwap(false, true) && b.cfg.OnExceeded != nil {
+		return b.snapshot(), true
+	}
+	return Cost{}, false
+}
+
+// fireOnExceeded runs the OnExceeded callback. Call it OUTSIDE windowMu.
+func (b *Budget[T]) fireOnExceeded(c Cost) {
+	if b.cfg.OnExceeded != nil {
+		b.safeCallback(b.cfg.OnExceeded, c)
 	}
 }
 

--- a/budget/budget.go
+++ b/budget/budget.go
@@ -95,6 +95,11 @@ type Config[T any] struct {
 	// then drive Reset manually.
 	ResetAfter time.Duration
 
+	// Clock supplies the current time for ResetAfter windowing. Nil
+	// defaults to time.Now. Override it to drive the rolling window from
+	// a deterministic or virtualized clock (tests, simulations).
+	Clock func() time.Time
+
 	// Logger receives diagnostic warnings (callback panics, breach
 	// notices). Nil disables internal logging.
 	Logger *slog.Logger
@@ -128,7 +133,11 @@ func New[T any](cfg Config[T]) (*Budget[T], error) {
 	if cfg.Max.Tokens <= 0 && cfg.Max.USDMicros <= 0 && cfg.Max.Calls <= 0 {
 		return nil, errors.New("budget.New: at least one Max field must be positive")
 	}
-	return &Budget[T]{cfg: cfg, now: time.Now}, nil
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	return &Budget[T]{cfg: cfg, now: clock}, nil
 }
 
 // Execute runs fn, charges the resulting cost against the budget, and

--- a/budget/budget_test.go
+++ b/budget/budget_test.go
@@ -246,6 +246,138 @@ func TestResetAfter_ZeroDisablesAutoReset(t *testing.T) {
 	}
 }
 
+// TestResetAfter_ConcurrentExecuteRaces hammers Execute from many goroutines
+// while the clock is advanced across the ResetAfter window boundary, under
+// -race. It guards the money-safety invariant that a window auto-reset never
+// interleaves with (and clobbers) a concurrent charge.
+//
+// Detector: the Charge callback returns Tokens and USDMicros that are ALWAYS
+// equal (both = 1 here). In the windowed Execute path both are applied together
+// in the same windowMu critical section, and the auto-reset clears all counters
+// in (with the fix) the same critical section. Therefore any snapshot taken
+// while holding windowMu must observe Tokens == USDMicros — they are written and
+// cleared as one atomic unit relative to the lock.
+//
+// With the bug the reset's tokens.Store(0) and usdMicros.Store(0) run OUTSIDE
+// windowMu, so a windowMu-guarded reader can catch the gap between the two
+// Stores, or a concurrent charge can land a tokens.Add that the reset clobbers
+// while leaving usdMicros (or vice-versa) — Tokens and USDMicros drift apart and
+// never re-converge. Unlike the public lock-free Consumed(), a windowMu-guarded
+// read is immune to benign torn reads, so a non-zero |Tokens-USDMicros| under
+// the lock is a true lost-charge / torn-reset signal.
+//
+// (Tokens/USDMicros, not Calls: the pre-charge increments Calls in a separate
+// earlier critical section, so Calls legitimately leads the other two by the
+// number of in-flight operations. Tokens and USDMicros are the pair applied
+// atomically together.)
+func TestResetAfter_ConcurrentExecuteRaces(t *testing.T) {
+	var mu sync.Mutex
+	clock := time.Unix(0, 0)
+	advance := func(d time.Duration) {
+		mu.Lock()
+		clock = clock.Add(d)
+		mu.Unlock()
+	}
+	nowFn := func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return clock
+	}
+
+	b, err := New[res](Config[res]{
+		// High caps so no goroutine trips the ceiling; we exercise the
+		// reset/charge race, not breach handling.
+		Max:        Cost{Tokens: 1_000_000_000, USDMicros: 1_000_000_000},
+		Charge:     func(_ context.Context, _ res, _ error) Cost { return Cost{Tokens: 1, USDMicros: 1} },
+		ResetAfter: time.Minute,
+		Clock:      nowFn,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	const workers = 64
+
+	var helpers sync.WaitGroup
+	var work sync.WaitGroup
+	stop := make(chan struct{})
+	var torn atomic.Bool
+	var worstDiff atomic.Int64
+
+	// Clock driver: continuously push past the window boundary so resets fire
+	// concurrently with in-flight Execute calls.
+	helpers.Add(1)
+	go func() {
+		defer helpers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				advance(time.Minute + time.Nanosecond)
+			}
+		}
+	}()
+
+	// Sampler: take a CONSISTENT snapshot under windowMu. Tokens and USDMicros
+	// are charged and reset together under the lock, so they must always match.
+	helpers.Add(1)
+	go func() {
+		defer helpers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				b.windowMu.Lock()
+				tokens := b.tokens.Load()
+				usd := b.usdMicros.Load()
+				b.windowMu.Unlock()
+				diff := tokens - usd
+				if diff < 0 {
+					diff = -diff
+				}
+				for {
+					w := worstDiff.Load()
+					if diff <= w || worstDiff.CompareAndSwap(w, diff) {
+						break
+					}
+				}
+				if diff != 0 {
+					torn.Store(true)
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < workers; i++ {
+		work.Add(1)
+		go func() {
+			defer work.Done()
+			for j := 0; j < 5_000; j++ {
+				_, _ = b.Execute(ctx, func(context.Context) (res, error) {
+					return res{}, nil
+				})
+			}
+		}()
+	}
+
+	work.Wait()    // all Execute hammering done
+	close(stop)    // release the clock driver and sampler
+	helpers.Wait() // and let them exit cleanly
+
+	if torn.Load() {
+		t.Fatalf("torn reset / lost charge: |Tokens-USDMicros| reached %d under windowMu (want 0)",
+			worstDiff.Load())
+	}
+
+	c := b.Consumed()
+	if c.Tokens < 0 || c.USDMicros < 0 || c.Calls < 0 {
+		t.Fatalf("impossible negative counters after concurrent run: %+v", c)
+	}
+}
+
 func TestBudgetExceededError_LogValue(t *testing.T) {
 	e := &BudgetExceededError{
 		Consumed: Cost{Tokens: 150, USDMicros: 2000, Calls: 5},

--- a/budget/budget_test.go
+++ b/budget/budget_test.go
@@ -177,16 +177,15 @@ func TestReset(t *testing.T) {
 }
 
 func TestResetAfter_AutoResetsOnceWindowElapses(t *testing.T) {
+	clock := time.Unix(0, 0)
 	b, err := New[res](Config[res]{
 		Max:        Cost{Calls: 1},
 		ResetAfter: time.Minute,
+		Clock:      func() time.Time { return clock },
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	clock := time.Unix(0, 0)
-	b.now = func() time.Time { return clock }
 
 	ctx := context.Background()
 
@@ -210,13 +209,12 @@ func TestResetAfter_AutoResetsOnceWindowElapses(t *testing.T) {
 }
 
 func TestResetAfter_DoesNotResetBeforeWindow(t *testing.T) {
+	clock := time.Unix(0, 0)
 	b, _ := New[res](Config[res]{
 		Max:        Cost{Calls: 2},
 		ResetAfter: time.Minute,
+		Clock:      func() time.Time { return clock },
 	})
-
-	clock := time.Unix(0, 0)
-	b.now = func() time.Time { return clock }
 
 	ctx := context.Background()
 	for i := 0; i < 2; i++ {
@@ -232,11 +230,11 @@ func TestResetAfter_DoesNotResetBeforeWindow(t *testing.T) {
 }
 
 func TestResetAfter_ZeroDisablesAutoReset(t *testing.T) {
-	b, _ := New[res](Config[res]{
-		Max: Cost{Calls: 1},
-	})
 	clock := time.Unix(0, 0)
-	b.now = func() time.Time { return clock }
+	b, _ := New[res](Config[res]{
+		Max:   Cost{Calls: 1},
+		Clock: func() time.Time { return clock },
+	})
 
 	ctx := context.Background()
 	_, _ = b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil })

--- a/budget/budget_test.go
+++ b/budget/budget_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type res struct{ tokens int64 }
@@ -172,6 +173,78 @@ func TestReset(t *testing.T) {
 	b.Reset()
 	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); err != nil {
 		t.Errorf("after reset: %v", err)
+	}
+}
+
+func TestResetAfter_AutoResetsOnceWindowElapses(t *testing.T) {
+	b, err := New[res](Config[res]{
+		Max:        Cost{Calls: 1},
+		ResetAfter: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock := time.Unix(0, 0)
+	b.now = func() time.Time { return clock }
+
+	ctx := context.Background()
+
+	// First call consumes the only allowed call.
+	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call within the window breaches.
+	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected breach within window, got %v", err)
+	}
+
+	// Advance time past the reset window; the next Execute should auto-reset.
+	clock = clock.Add(time.Minute + time.Nanosecond)
+	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); err != nil {
+		t.Fatalf("expected auto-reset to clear budget, got %v", err)
+	}
+	if c := b.Consumed(); c.Calls != 1 {
+		t.Errorf("after auto-reset Calls = %d, want 1", c.Calls)
+	}
+}
+
+func TestResetAfter_DoesNotResetBeforeWindow(t *testing.T) {
+	b, _ := New[res](Config[res]{
+		Max:        Cost{Calls: 2},
+		ResetAfter: time.Minute,
+	})
+
+	clock := time.Unix(0, 0)
+	b.now = func() time.Time { return clock }
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		clock = clock.Add(10 * time.Second) // still inside the window
+	}
+	// Third call, total elapsed 20s < 1m, must breach (no reset yet).
+	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected breach before window elapsed, got %v", err)
+	}
+}
+
+func TestResetAfter_ZeroDisablesAutoReset(t *testing.T) {
+	b, _ := New[res](Config[res]{
+		Max: Cost{Calls: 1},
+	})
+	clock := time.Unix(0, 0)
+	b.now = func() time.Time { return clock }
+
+	ctx := context.Background()
+	_, _ = b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil })
+
+	// Even far in the future, with ResetAfter unset the budget stays breached.
+	clock = clock.Add(24 * time.Hour)
+	if _, err := b.Execute(ctx, func(context.Context) (res, error) { return res{}, nil }); !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected sustained breach with ResetAfter=0, got %v", err)
 	}
 }
 

--- a/costbudget.go
+++ b/costbudget.go
@@ -2,6 +2,7 @@ package fortify
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -30,8 +31,10 @@ const usdMicrosPerUSD = 1_000_000
 // cost dimensions.
 type CostBudgetConfig struct {
 	// MaxCost is the spending ceiling in US dollars (e.g. 5.0 = $5.00).
-	// Must be positive; a non-positive value makes WithCostBudget a no-op
-	// that never gates (and is almost always a misconfiguration).
+	// Must be a positive, finite value that does not overflow the budget's
+	// micro-USD dimension. An invalid MaxCost (non-positive, NaN, Inf, or
+	// overflowing) panics WithCostBudget: a spend cap silently disabled by a
+	// typo is the wrong default for a safety control.
 	MaxCost float64
 
 	// CostFunc reports the cost, in US dollars, that an operation
@@ -39,12 +42,17 @@ type CostBudgetConfig struct {
 	// failed attempt that still cost money can be charged. The result is
 	// passed as any; type-assert it to your operation's result type.
 	// Nil charges nothing (the budget then never advances on cost).
+	//
+	// A non-finite or overflowing return (NaN, Inf, or a value whose
+	// micro-USD conversion would overflow int64) is treated as zero so a
+	// bad cost reading cannot corrupt accounting or instantly breach.
 	CostFunc func(result any, err error) float64
 
 	// ResetAfter, when positive, turns the budget into a rolling window:
 	// the accumulated spend is automatically cleared once this much
 	// wall-clock time has elapsed. Zero (the default) makes the ceiling
-	// apply for the lifetime of the chain.
+	// apply for the lifetime of the chain. The window is wall-clock and
+	// independent of any ctx deadline or cancellation.
 	ResetAfter time.Duration
 
 	// clock overrides the time source for ResetAfter windowing. Unexported;
@@ -93,19 +101,30 @@ func New[T any]() *Composer[T] {
 // auto-reset via ResetAfter. For tokens/calls dimensions, OnExceeded
 // callbacks, or sharing one budget across chains, use the budget package
 // with middleware.Chain.WithBudget directly.
+//
+// It PANICS if cfg.MaxCost is invalid (non-positive, NaN, Inf, or large
+// enough to overflow the micro-USD dimension). This is a programmer error in
+// a fluent builder: silently degrading a spend cap to a no-op is the wrong
+// default for a safety control.
 func (c *Composer[T]) WithCostBudget(cfg CostBudgetConfig) *Composer[T] {
+	micros, ok := usdToMicros(cfg.MaxCost)
+	if !ok {
+		panic(fmt.Sprintf(
+			"fortify.WithCostBudget: invalid MaxCost %v: must be a positive, finite USD value that does not overflow micro-USD",
+			cfg.MaxCost,
+		))
+	}
 	b, err := budget.New[T](budget.Config[T]{
-		Max:        budget.Cost{USDMicros: usdToMicros(cfg.MaxCost)},
+		Max:        budget.Cost{USDMicros: micros},
 		Charge:     costFuncToCharge[T](cfg.CostFunc),
 		ResetAfter: cfg.ResetAfter,
 		Clock:      cfg.clock,
 	})
 	if err != nil {
-		// Max non-positive: register a pass-through so the chain still
-		// composes. A non-positive ceiling cannot gate anything, matching
-		// "no budget configured" semantics rather than panicking the
-		// builder.
-		return c
+		// usdToMicros already guaranteed a positive USDMicros, so budget.New
+		// cannot reject for an empty Max here; surface anything unexpected
+		// rather than silently disabling the cap.
+		panic(fmt.Sprintf("fortify.WithCostBudget: %v", err))
 	}
 	c.chain.WithBudget(b)
 	return c
@@ -116,27 +135,44 @@ func (c *Composer[T]) Execute(ctx context.Context, fn func(context.Context) (T, 
 	return c.chain.Execute(ctx, fn)
 }
 
-// usdToMicros converts whole US dollars to integer micro-USD, rounding to
-// the nearest micro. Non-positive input yields 0 so budget.New rejects it.
-func usdToMicros(usd float64) int64 {
-	if usd <= 0 {
-		return 0
+// usdToMicros converts whole US dollars to integer micro-USD, rounding to the
+// nearest micro. It is the single guarded conversion shared by the MaxCost
+// ceiling and the per-call CostFunc charge so the safety guards cannot drift
+// between the two call sites.
+//
+// It returns ok=false for any value that cannot be safely represented:
+// non-positive, NaN, ±Inf, or a magnitude that would overflow int64 after
+// scaling. Callers decide how an invalid value surfaces (MaxCost panics; a
+// bad CostFunc return charges nothing).
+func usdToMicros(usd float64) (micros int64, ok bool) {
+	if math.IsNaN(usd) || math.IsInf(usd, 0) || usd <= 0 {
+		return 0, false
 	}
-	return int64(math.Round(usd * usdMicrosPerUSD))
+	scaled := usd * usdMicrosPerUSD
+	// Guard the rounded result against int64 overflow. math.MaxInt64 is not
+	// exactly representable as a float64; comparing against the next lower
+	// representable value (2^63, i.e. float64(math.MaxInt64)+1 rounds up) keeps
+	// the conversion strictly inside range.
+	if scaled >= float64(math.MaxInt64) {
+		return 0, false
+	}
+	return int64(math.Round(scaled)), true
 }
 
-// costFuncToCharge adapts the convenience CostFunc (float USD over any)
-// to the budget package's typed Charge (Cost over T). A nil CostFunc
-// charges nothing.
+// costFuncToCharge adapts the convenience CostFunc (float USD over any) to the
+// budget package's typed Charge (Cost over T). A nil CostFunc charges nothing.
+// A non-positive, non-finite, or overflowing return is guarded to charge zero
+// via the shared usdToMicros helper, so a bad cost reading cannot corrupt
+// accounting or saturate to an instant breach.
 func costFuncToCharge[T any](costFunc func(result any, err error) float64) budget.Charge[T] {
 	if costFunc == nil {
 		return nil
 	}
 	return func(_ context.Context, result T, err error) budget.Cost {
-		usd := costFunc(any(result), err)
-		if usd <= 0 {
+		micros, ok := usdToMicros(costFunc(result, err))
+		if !ok {
 			return budget.Cost{}
 		}
-		return budget.Cost{USDMicros: int64(math.Round(usd * usdMicrosPerUSD))}
+		return budget.Cost{USDMicros: micros}
 	}
 }

--- a/costbudget.go
+++ b/costbudget.go
@@ -6,8 +6,15 @@ import (
 	"math"
 	"time"
 
+	"go.klarlabs.de/fortify/adaptive"
 	"go.klarlabs.de/fortify/budget"
+	"go.klarlabs.de/fortify/bulkhead"
+	"go.klarlabs.de/fortify/circuitbreaker"
+	"go.klarlabs.de/fortify/hedge"
 	"go.klarlabs.de/fortify/middleware"
+	"go.klarlabs.de/fortify/ratelimit"
+	"go.klarlabs.de/fortify/retry"
+	"go.klarlabs.de/fortify/timeout"
 )
 
 // ErrBudgetExceeded is returned (wrapped) by a chain carrying a cost
@@ -62,10 +69,15 @@ type CostBudgetConfig struct {
 	Clock func() time.Time
 }
 
-// Composer is the fluent entry point for assembling a resilience pipeline
-// from the top-level fortify package. It wraps the middleware.Chain
-// composer so spec-level convenience methods (WithCostBudget) and the
-// lower-level pattern wiring share one execution model.
+// Composer is the curated, fluent entry point for assembling a resilience
+// pipeline from the top-level fortify package. It wraps middleware.Chain and
+// re-exposes its pattern builders so the curated surface is not a dead end,
+// while adding the spec-level convenience method WithCostBudget.
+//
+// Composer covers the common patterns. For the full toolkit (WithAdaptive,
+// WithHedge, custom ordering, or sharing one pattern instance across chains)
+// drop down to middleware.Chain directly; Composer is a thin delegating
+// wrapper over it.
 //
 // Build a Composer with New, attach policies, then call Execute.
 type Composer[T any] struct {
@@ -121,6 +133,49 @@ func (c *Composer[T]) WithCostBudget(cfg CostBudgetConfig) *Composer[T] {
 		panic(fmt.Sprintf("fortify.WithCostBudget: %v", err))
 	}
 	c.chain.WithBudget(b)
+	return c
+}
+
+// WithCircuitBreaker delegates to middleware.Chain.WithCircuitBreaker.
+func (c *Composer[T]) WithCircuitBreaker(cb circuitbreaker.CircuitBreaker[T]) *Composer[T] {
+	c.chain.WithCircuitBreaker(cb)
+	return c
+}
+
+// WithRetry delegates to middleware.Chain.WithRetry.
+func (c *Composer[T]) WithRetry(r retry.Retry[T]) *Composer[T] {
+	c.chain.WithRetry(r)
+	return c
+}
+
+// WithRateLimit delegates to middleware.Chain.WithRateLimit. The key
+// identifies the rate-limit bucket (e.g. user ID, IP address).
+func (c *Composer[T]) WithRateLimit(rl ratelimit.RateLimiter, key string) *Composer[T] {
+	c.chain.WithRateLimit(rl, key)
+	return c
+}
+
+// WithTimeout delegates to middleware.Chain.WithTimeout.
+func (c *Composer[T]) WithTimeout(tm timeout.Timeout[T], duration time.Duration) *Composer[T] {
+	c.chain.WithTimeout(tm, duration)
+	return c
+}
+
+// WithBulkhead delegates to middleware.Chain.WithBulkhead.
+func (c *Composer[T]) WithBulkhead(bh bulkhead.Bulkhead[T]) *Composer[T] {
+	c.chain.WithBulkhead(bh)
+	return c
+}
+
+// WithAdaptive delegates to middleware.Chain.WithAdaptive.
+func (c *Composer[T]) WithAdaptive(a adaptive.Limiter[T]) *Composer[T] {
+	c.chain.WithAdaptive(a)
+	return c
+}
+
+// WithHedge delegates to middleware.Chain.WithHedge.
+func (c *Composer[T]) WithHedge(h hedge.Hedge[T]) *Composer[T] {
+	c.chain.WithHedge(h)
 	return c
 }
 

--- a/costbudget.go
+++ b/costbudget.go
@@ -55,17 +55,11 @@ type CostBudgetConfig struct {
 	// independent of any ctx deadline or cancellation.
 	ResetAfter time.Duration
 
-	// clock overrides the time source for ResetAfter windowing. Unexported;
-	// set via WithClockForTest. Nil defaults to time.Now.
-	clock func() time.Time
-}
-
-// WithClockForTest returns a copy of the config with a custom clock used
-// to drive the ResetAfter window. It exists so callers (and tests) can
-// exercise auto-reset deterministically without sleeping.
-func (c CostBudgetConfig) WithClockForTest(now func() time.Time) CostBudgetConfig {
-	c.clock = now
-	return c
+	// Clock supplies the current time for ResetAfter windowing. Nil defaults
+	// to time.Now. Override it to drive the rolling window from a
+	// deterministic or virtualized clock (tests, simulations). Mirrors
+	// budget.Config.Clock.
+	Clock func() time.Time
 }
 
 // Composer is the fluent entry point for assembling a resilience pipeline
@@ -118,7 +112,7 @@ func (c *Composer[T]) WithCostBudget(cfg CostBudgetConfig) *Composer[T] {
 		Max:        budget.Cost{USDMicros: micros},
 		Charge:     costFuncToCharge[T](cfg.CostFunc),
 		ResetAfter: cfg.ResetAfter,
-		Clock:      cfg.clock,
+		Clock:      cfg.Clock,
 	})
 	if err != nil {
 		// usdToMicros already guaranteed a positive USDMicros, so budget.New

--- a/costbudget.go
+++ b/costbudget.go
@@ -1,0 +1,142 @@
+package fortify
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"go.klarlabs.de/fortify/budget"
+	"go.klarlabs.de/fortify/middleware"
+)
+
+// ErrBudgetExceeded is returned (wrapped) by a chain carrying a cost
+// budget once the configured ceiling is reached. Match it with
+// errors.Is. It re-exports budget.ErrBudgetExceeded so the convenience
+// API and the lower-level budget package share a single sentinel.
+var ErrBudgetExceeded = budget.ErrBudgetExceeded
+
+// usdMicrosPerUSD converts whole US dollars to integer micro-USD, the
+// unit the underlying budget package accumulates in to avoid float drift.
+const usdMicrosPerUSD = 1_000_000
+
+// CostBudgetConfig configures a single-dimension monetary cost budget for
+// the fluent fortify composer. It is the spec's convenience surface over
+// the richer multidimensional budget package: costs are expressed as
+// floating-point US dollars and mapped onto the budget's integer
+// micro-USD dimension.
+//
+// Use the lower-level budget package directly when you need to cap
+// tokens or call counts, fire OnExceeded callbacks, or combine multiple
+// cost dimensions.
+type CostBudgetConfig struct {
+	// MaxCost is the spending ceiling in US dollars (e.g. 5.0 = $5.00).
+	// Must be positive; a non-positive value makes WithCostBudget a no-op
+	// that never gates (and is almost always a misconfiguration).
+	MaxCost float64
+
+	// CostFunc reports the cost, in US dollars, that an operation
+	// consumed. It is invoked once per call regardless of err, so a
+	// failed attempt that still cost money can be charged. The result is
+	// passed as any; type-assert it to your operation's result type.
+	// Nil charges nothing (the budget then never advances on cost).
+	CostFunc func(result any, err error) float64
+
+	// ResetAfter, when positive, turns the budget into a rolling window:
+	// the accumulated spend is automatically cleared once this much
+	// wall-clock time has elapsed. Zero (the default) makes the ceiling
+	// apply for the lifetime of the chain.
+	ResetAfter time.Duration
+
+	// clock overrides the time source for ResetAfter windowing. Unexported;
+	// set via WithClockForTest. Nil defaults to time.Now.
+	clock func() time.Time
+}
+
+// WithClockForTest returns a copy of the config with a custom clock used
+// to drive the ResetAfter window. It exists so callers (and tests) can
+// exercise auto-reset deterministically without sleeping.
+func (c CostBudgetConfig) WithClockForTest(now func() time.Time) CostBudgetConfig {
+	c.clock = now
+	return c
+}
+
+// Composer is the fluent entry point for assembling a resilience pipeline
+// from the top-level fortify package. It wraps the middleware.Chain
+// composer so spec-level convenience methods (WithCostBudget) and the
+// lower-level pattern wiring share one execution model.
+//
+// Build a Composer with New, attach policies, then call Execute.
+type Composer[T any] struct {
+	chain *middleware.Chain[T]
+}
+
+// New creates an empty Composer for operations returning T.
+//
+//	out, err := fortify.New[Response]().
+//	    WithCostBudget(fortify.CostBudgetConfig{
+//	        MaxCost: 5.0,
+//	        CostFunc: func(result any, _ error) float64 {
+//	            return result.(Response).USDCost
+//	        },
+//	    }).
+//	    Execute(ctx, callLLM)
+func New[T any]() *Composer[T] {
+	return &Composer[T]{chain: middleware.New[T]()}
+}
+
+// WithCostBudget attaches a monetary cost budget to the composer. Once the
+// accumulated cost exceeds MaxCost, Execute returns an error matching
+// ErrBudgetExceeded and the operation is refused.
+//
+// It is a thin wrapper over the budget package: a single USD/float ceiling
+// mapped to the budget's micro-USD dimension, with optional time-based
+// auto-reset via ResetAfter. For tokens/calls dimensions, OnExceeded
+// callbacks, or sharing one budget across chains, use the budget package
+// with middleware.Chain.WithBudget directly.
+func (c *Composer[T]) WithCostBudget(cfg CostBudgetConfig) *Composer[T] {
+	b, err := budget.New[T](budget.Config[T]{
+		Max:        budget.Cost{USDMicros: usdToMicros(cfg.MaxCost)},
+		Charge:     costFuncToCharge[T](cfg.CostFunc),
+		ResetAfter: cfg.ResetAfter,
+		Clock:      cfg.clock,
+	})
+	if err != nil {
+		// Max non-positive: register a pass-through so the chain still
+		// composes. A non-positive ceiling cannot gate anything, matching
+		// "no budget configured" semantics rather than panicking the
+		// builder.
+		return c
+	}
+	c.chain.WithBudget(b)
+	return c
+}
+
+// Execute runs fn through the composed pipeline.
+func (c *Composer[T]) Execute(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
+	return c.chain.Execute(ctx, fn)
+}
+
+// usdToMicros converts whole US dollars to integer micro-USD, rounding to
+// the nearest micro. Non-positive input yields 0 so budget.New rejects it.
+func usdToMicros(usd float64) int64 {
+	if usd <= 0 {
+		return 0
+	}
+	return int64(math.Round(usd * usdMicrosPerUSD))
+}
+
+// costFuncToCharge adapts the convenience CostFunc (float USD over any)
+// to the budget package's typed Charge (Cost over T). A nil CostFunc
+// charges nothing.
+func costFuncToCharge[T any](costFunc func(result any, err error) float64) budget.Charge[T] {
+	if costFunc == nil {
+		return nil
+	}
+	return func(_ context.Context, result T, err error) budget.Cost {
+		usd := costFunc(any(result), err)
+		if usd <= 0 {
+			return budget.Cost{}
+		}
+		return budget.Cost{USDMicros: int64(math.Round(usd * usdMicrosPerUSD))}
+	}
+}

--- a/costbudget_test.go
+++ b/costbudget_test.go
@@ -80,11 +80,14 @@ func TestWithCostBudget_CostFuncSeesResultAndError(t *testing.T) {
 
 func TestWithCostBudget_ResetAfterAutoResets(t *testing.T) {
 	clock := time.Unix(0, 0)
+	// Clock is a public config field (mirroring budget.Config.Clock); it drives
+	// the ResetAfter window deterministically without sleeping.
 	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
 		MaxCost:    1.0,
 		CostFunc:   func(any, error) float64 { return 0.75 },
 		ResetAfter: time.Minute,
-	}.WithClockForTest(func() time.Time { return clock }))
+		Clock:      func() time.Time { return clock },
+	})
 
 	ctx := context.Background()
 

--- a/costbudget_test.go
+++ b/costbudget_test.go
@@ -3,6 +3,7 @@ package fortify_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -83,7 +84,6 @@ func TestWithCostBudget_ResetAfterAutoResets(t *testing.T) {
 		MaxCost:    1.0,
 		CostFunc:   func(any, error) float64 { return 0.75 },
 		ResetAfter: time.Minute,
-		// nowForTest is an unexported test hook on the config; see below.
 	}.WithClockForTest(func() time.Time { return clock }))
 
 	ctx := context.Background()
@@ -101,6 +101,70 @@ func TestWithCostBudget_ResetAfterAutoResets(t *testing.T) {
 	clock = clock.Add(time.Minute + time.Nanosecond)
 	if _, err := chain.Execute(ctx, func(context.Context) (string, error) { return "", nil }); err != nil {
 		t.Fatalf("expected auto-reset after ResetAfter, got %v", err)
+	}
+}
+
+func TestWithCostBudget_PanicsOnInvalidMaxCost(t *testing.T) {
+	cases := []struct {
+		name    string
+		maxCost float64
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"NaN", math.NaN()},
+		{"PosInf", math.Inf(1)},
+		{"NegInf", math.Inf(-1)},
+		{"overflow", 1e18}, // 1e18 * 1e6 overflows int64 micro-USD
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatalf("expected panic for MaxCost=%v, got none", tc.maxCost)
+				}
+			}()
+			fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+				MaxCost:  tc.maxCost,
+				CostFunc: func(any, error) float64 { return 0 },
+			})
+		})
+	}
+}
+
+func TestWithCostBudget_ValidMaxCostDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic for valid MaxCost: %v", r)
+		}
+	}()
+	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost:  5.0,
+		CostFunc: func(any, error) float64 { return 1.0 },
+	})
+	if _, err := chain.Execute(context.Background(), func(context.Context) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestWithCostBudget_CostFuncNaNInfOverflowChargesNothing(t *testing.T) {
+	// A bad CostFunc return (NaN/Inf/overflow) must not corrupt the budget:
+	// it is guarded to charge nothing rather than saturating to int64-max and
+	// instantly breaching, or producing a torn micro-USD value.
+	for _, bad := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), 1e18, -1.0} {
+		chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+			MaxCost:  1.0,
+			CostFunc: func(any, error) float64 { return bad },
+		})
+		// Several calls with a bad cost must never breach (nothing charged).
+		for i := 0; i < 5; i++ {
+			if _, err := chain.Execute(context.Background(), func(context.Context) (string, error) {
+				return "ok", nil
+			}); err != nil {
+				t.Fatalf("bad cost %v call %d: unexpected breach: %v", bad, i, err)
+			}
+		}
 	}
 }
 

--- a/costbudget_test.go
+++ b/costbudget_test.go
@@ -1,0 +1,129 @@
+package fortify_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/fortify"
+)
+
+func TestWithCostBudget_AccumulatesUntilExceeded(t *testing.T) {
+	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost: 1.0, // $1.00 ceiling
+		CostFunc: func(_ any, _ error) float64 {
+			return 0.30 // $0.30 per call
+		},
+	})
+
+	ctx := context.Background()
+
+	// 0.30 * 3 = 0.90 <= 1.00 : allowed.
+	for i := 0; i < 3; i++ {
+		if _, err := chain.Execute(ctx, func(context.Context) (string, error) {
+			return "ok", nil
+		}); err != nil {
+			t.Fatalf("call %d unexpected err: %v", i, err)
+		}
+	}
+
+	// 4th call pushes to 1.20 > 1.00 : breach.
+	_, err := chain.Execute(ctx, func(context.Context) (string, error) {
+		return "ok", nil
+	})
+	if !errors.Is(err, fortify.ErrBudgetExceeded) {
+		t.Fatalf("expected fortify.ErrBudgetExceeded, got %v", err)
+	}
+}
+
+func TestWithCostBudget_ErrorsIsMatchesBudgetSentinel(t *testing.T) {
+	chain := fortify.New[int]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost:  0.50,
+		CostFunc: func(any, error) float64 { return 1.0 },
+	})
+
+	_, err := chain.Execute(context.Background(), func(context.Context) (int, error) {
+		return 1, nil
+	})
+	if !errors.Is(err, fortify.ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded via errors.Is, got %v", err)
+	}
+}
+
+func TestWithCostBudget_CostFuncSeesResultAndError(t *testing.T) {
+	var gotResult any
+	var gotErr error
+	sentinel := errors.New("upstream failure")
+
+	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost: 100.0,
+		CostFunc: func(result any, err error) float64 {
+			gotResult = result
+			gotErr = err
+			return 1.0
+		},
+	})
+
+	_, _ = chain.Execute(context.Background(), func(context.Context) (string, error) {
+		return "payload", sentinel
+	})
+
+	if gotResult != "payload" {
+		t.Errorf("CostFunc result = %v, want \"payload\"", gotResult)
+	}
+	if !errors.Is(gotErr, sentinel) {
+		t.Errorf("CostFunc err = %v, want sentinel", gotErr)
+	}
+}
+
+func TestWithCostBudget_ResetAfterAutoResets(t *testing.T) {
+	clock := time.Unix(0, 0)
+	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost:    1.0,
+		CostFunc:   func(any, error) float64 { return 0.75 },
+		ResetAfter: time.Minute,
+		// nowForTest is an unexported test hook on the config; see below.
+	}.WithClockForTest(func() time.Time { return clock }))
+
+	ctx := context.Background()
+
+	// First call: 0.75 <= 1.0, allowed.
+	if _, err := chain.Execute(ctx, func(context.Context) (string, error) { return "", nil }); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	// Second call: 1.50 > 1.0, breach within the window.
+	if _, err := chain.Execute(ctx, func(context.Context) (string, error) { return "", nil }); !errors.Is(err, fortify.ErrBudgetExceeded) {
+		t.Fatalf("expected breach within window, got %v", err)
+	}
+
+	// Advance past the window; the budget must auto-reset.
+	clock = clock.Add(time.Minute + time.Nanosecond)
+	if _, err := chain.Execute(ctx, func(context.Context) (string, error) { return "", nil }); err != nil {
+		t.Fatalf("expected auto-reset after ResetAfter, got %v", err)
+	}
+}
+
+func TestWithCostBudget_ComposesWithinChain(t *testing.T) {
+	calls := 0
+	chain := fortify.New[string]().WithCostBudget(fortify.CostBudgetConfig{
+		MaxCost:  1.0,
+		CostFunc: func(any, error) float64 { return 0.60 },
+	})
+
+	ctx := context.Background()
+	op := func(context.Context) (string, error) {
+		calls++
+		return "v", nil
+	}
+
+	if _, err := chain.Execute(ctx, op); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := chain.Execute(ctx, op); !errors.Is(err, fortify.ErrBudgetExceeded) {
+		t.Fatalf("expected breach on second, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("operation invoked %d times, want 2 (charged even on breaching call)", calls)
+	}
+}

--- a/costbudget_test.go
+++ b/costbudget_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"go.klarlabs.de/fortify"
+	"go.klarlabs.de/fortify/retry"
+	"go.klarlabs.de/fortify/timeout"
 )
 
 func TestWithCostBudget_AccumulatesUntilExceeded(t *testing.T) {
@@ -168,6 +170,39 @@ func TestWithCostBudget_CostFuncNaNInfOverflowChargesNothing(t *testing.T) {
 				t.Fatalf("bad cost %v call %d: unexpected breach: %v", bad, i, err)
 			}
 		}
+	}
+}
+
+func TestComposer_DelegatesChainPatterns(t *testing.T) {
+	// The curated Composer must not be a WithCostBudget-only dead end: it
+	// exposes the other chain patterns by delegating to the embedded chain.
+	rt := retry.New[string](retry.Config{MaxAttempts: 3, InitialDelay: time.Microsecond})
+	tm := timeout.New[string](timeout.Config{})
+
+	attempts := 0
+	chain := fortify.New[string]().
+		WithRetry(rt).
+		WithTimeout(tm, time.Second).
+		WithCostBudget(fortify.CostBudgetConfig{
+			MaxCost:  100.0,
+			CostFunc: func(any, error) float64 { return 1.0 },
+		})
+
+	out, err := chain.Execute(context.Background(), func(context.Context) (string, error) {
+		attempts++
+		if attempts < 2 {
+			return "", errors.New("transient")
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("delegated chain Execute err: %v", err)
+	}
+	if out != "ok" {
+		t.Errorf("out = %q, want \"ok\"", out)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2 (retry delegated)", attempts)
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -153,6 +153,31 @@
 //	    return apiClient.Call(ctx)
 //	})
 //
+// # Cost Budgets
+//
+// For operations whose cost cannot be capped by attempt count alone
+// (LLM calls, paid APIs), the top-level composer offers a monetary cost
+// budget. Costs are expressed in US dollars; ResetAfter optionally turns
+// the ceiling into a rolling time window.
+//
+//	out, err := fortify.New[Response]().
+//	    WithCostBudget(fortify.CostBudgetConfig{
+//	        MaxCost:    5.00, // $5 ceiling
+//	        ResetAfter: time.Hour,
+//	        CostFunc: func(result any, _ error) float64 {
+//	            return result.(Response).USDCost
+//	        },
+//	    }).
+//	    Execute(ctx, callProvider)
+//
+//	if errors.Is(err, fortify.ErrBudgetExceeded) {
+//	    // ceiling reached; operation refused
+//	}
+//
+// For token or call-count ceilings, OnExceeded callbacks, or sharing one
+// budget across chains, use the budget package with
+// middleware.Chain.WithBudget directly.
+//
 // # HTTP Integration
 //
 // Use resilience patterns as HTTP middleware:


### PR DESCRIPTION
Adds the authoritative spec's public cost-budget surface as a thin wrapper over the richer budget package, plus review hardening.

- `fortify.New[T]().WithCostBudget(CostBudgetConfig{MaxCost, CostFunc, ResetAfter})` + `fortify.ErrBudgetExceeded`.
- ResetAfter rolling auto-reset made atomic vs concurrent Execute (windowed path under one mutex; lock-free fast path when ResetAfter==0). 64-goroutine -race test, RED→GREEN.
- Money conversion guards NaN/Inf/overflow; WithCostBudget panics on invalid MaxCost instead of silently disabling the cap.
- Public injectable Clock; Composer delegates the full pattern set (no dead end).
- Core stays zero-dep. go build/vet/test -race/gofmt clean (26 pkgs).

Paired with fortify-ts feat/costbudget-spec-align (lockstep).

https://claude.ai/code/session_01Cah5LkQHbpxog74NLpujQ9