### PR TITLE
ci: drop cross-platform matrix + redundant benchmark from every-push CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 # Thin caller for the shared klarlabs-studio Go CI bar.
 # All gate logic lives in the reusable workflow — bump versions / add jobs
-# there, once, org-wide. fortify is perf-sensitive and validates multi-OS on
-# push to main, so coverage, benchmark, and cross-platform are all enabled.
+# there, once, org-wide.
 name: CI
 
 on:
@@ -32,5 +31,13 @@ jobs:
     secrets: inherit
     with:
       coverage: true
-      benchmark: true
-      cross-platform: true
+      # cross-platform OFF: fortify is pure-Go resilience code with no
+      # OS-specific paths/syscalls/build-tags, so a macOS (10x billing) +
+      # Windows matrix on every push to main validated nothing — Go's own
+      # runtime guarantees identical behaviour. This was the bulk of the repo's
+      # Actions spend. Re-enable only if OS-specific source is ever added.
+      cross-platform: false
+      # benchmark OFF here: the dedicated weekly performance.yml already runs
+      # `go test -bench` with history comparison (gh-pages). Running it again on
+      # every push to main was redundant.
+      benchmark: false


### PR DESCRIPTION
## Why
fortify's Actions spend is the org's only meaningful net-billable line (~20.5k Linux min, $59.84 this cycle) — and because the org spending limit is low, that billable usage **blocks every other private repo's CI** (pet-medical included, which is how this surfaced).

## What's wasteful
- **`cross-platform: true`** ran a 3-OS matrix (ubuntu + macOS + Windows) on every push to main. macOS bills at **10×**. But fortify is **pure-Go resilience code** — verified no `syscall`, no `runtime.GOOS`, no build tags, no `*_windows.go`/`*_darwin.go`. Nothing OS-specific to validate; Go's runtime guarantees identical behaviour. This was the bulk of the spend.
- **`benchmark: true`** on every push duplicated the dedicated weekly `performance.yml` (proper benchmark history comparison via gh-pages).

## Change
Both flags → `false` (with rationale comments). Cuts push-to-main from ~7 jobs to ~4, eliminates all macOS/Windows minutes.

## No coverage loss
- PRs were **already ubuntu-only** (the shared `go-ci.yml` gates the matrix to non-PR events) — PR feedback identical.
- Benchmarks still run weekly via `performance.yml`.
- Coverage gate stays on.

Re-enable `cross-platform` only if OS-specific source is ever added.

https://claude.ai/code/session_01KhcxqzoC2dgi2QibzBn3Sy