### PR TITLE
fix(security): bump pymdown-extensions to a patched version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.49
-pymdown-extensions==10.21.3
+mkdocs-material==9.7.7
+pymdown-extensions==11.0.0


### PR DESCRIPTION
## What
Clears **GHSA-9xwg-3r6f-jcx2 / CVE-2026-61632** (medium) — path traversal in pymdown-extensions' `b64` extension.

| Dependency | From → To |
|---|---|
| `pymdown-extensions` | 10.21.3 → **11.0.0** |
| `mkdocs-material` | 9.5.49 → **9.7.7** |

## Why mkdocs-material moves too
`mkdocs-material==9.5.49` pins `pymdown-extensions~=10.2`, so the patched 11.0.0 is **incompatible** with it — bumping pymdown alone would break the docs build. `9.7.7` relaxes the constraint to `>=10.2`, so the pair upgrades cleanly and stays within mkdocs-material 9.x (no major bump).

## Risk
Exposure was already nil: `mkdocs.yml` enables only `pymdownx.details`, `superfences`, `tabbed` and `tasklist` — **not** the vulnerable `b64` extension. This is hygiene, not an incident. Docs-only dependency; no runtime/library impact.

## Verification
`mkdocs build` — the exact command `.github/workflows/docs.yml` runs (CI deliberately omits `--strict`; there's a comment explaining why) — succeeds on the upgraded set: *"Documentation built in 1.44 seconds"*.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom