### PR TITLE
docs(ratelimit): document Rate as per-Interval so sub-1/sec quotas are findable

### DIFF
--- a/docs/how-to-rate-limit.md
+++ b/docs/how-to-rate-limit.md
@@ -16,6 +16,39 @@ if !rl.Allow(ctx, "global") {
 }
 ```
 
+## Per-minute (and per-hour) quotas
+
+`Rate` is a count **per `Interval`**, not per second. `Interval` carries the
+unit, so a quota published per minute — the form most LLM and third-party APIs
+use — transcribes directly, with no per-second arithmetic:
+
+```go
+// Provider tier documented as "50 RPM".
+rl := ratelimit.New(ratelimit.Config{
+    Rate:     50,
+    Interval: time.Minute,
+    Burst:    10, // cap how much of the quota a single spike may claim
+})
+```
+
+| Quota            | `Rate` | `Interval`    |
+| ---------------- | ------ | ------------- |
+| 10 req/second    | `10`   | `time.Second` |
+| 50 req/minute    | `50`   | `time.Minute` |
+| 4000 req/minute  | `4000` | `time.Minute` |
+| 500 req/hour     | `500`  | `time.Hour`   |
+
+Widening `Interval` is how sustained rates **below one request per second** are
+expressed; `Rate` never needs to be fractional. `Rate: 50, Interval: time.Minute`
+is 0.83 req/sec, which no integer `Rate` at `Interval: time.Second` could state.
+
+Refill is continuous, not stepped: the example above returns roughly one token
+every 1.2s rather than 50 tokens at the top of each minute. `Burst` is the bucket
+capacity and therefore the largest spike allowed — set it equal to `Rate` for a
+strict quota, or lower to smooth traffic further.
+
+`Interval` is clamped to `[MinInterval, MaxInterval]` (1ms to 24h).
+
 ## Per-client limit
 
 ```go

--- a/ratelimit/config.go
+++ b/ratelimit/config.go
@@ -80,12 +80,29 @@ type Config struct {
 
 	// Interval is the time period over which Rate tokens are added.
 	// Defaults to 1 second if zero.
+	//
+	// Interval is the unit of Rate: together they express any quota, not
+	// just per-second ones. Set it to time.Minute to transcribe a
+	// requests-per-minute quota (the form most third-party and LLM
+	// provider docs use) without converting to a per-second figure.
+	//
+	// Refill is continuous, not stepped: with Rate=50 and
+	// Interval=time.Minute one token returns roughly every 1.2s rather
+	// than 50 arriving at once each minute.
+	//
+	// Clamped to [MinInterval, MaxInterval].
 	Interval time.Duration
 
 	// Rate is the number of tokens added to the bucket per Interval.
 	// Must be positive. Defaults to 100 if zero or negative.
 	//
-	// Example: Rate=10 with Interval=time.Second allows 10 requests per second.
+	// Rate is always read relative to Interval, so sub-1/sec sustained
+	// rates are expressed by widening Interval rather than by a
+	// fractional Rate:
+	//
+	//	Rate: 10,  Interval: time.Second  // 10 requests/second
+	//	Rate: 50,  Interval: time.Minute  // 50 requests/minute (0.83/sec)
+	//	Rate: 500, Interval: time.Hour    // 500 requests/hour
 	Rate int
 
 	// Burst is the maximum number of tokens in the bucket (bucket capacity).

--- a/ratelimit/doc.go
+++ b/ratelimit/doc.go
@@ -22,6 +22,31 @@
 //	    // Return 429 Too Many Requests
 //	}
 //
+// # Expressing a Quota
+//
+// Rate is a count per Interval, so the pair expresses any quota — the
+// Interval is what carries the unit, and it is not restricted to seconds:
+//
+//	Rate: 10,  Interval: time.Second  // 10 requests/second
+//	Rate: 50,  Interval: time.Minute  // 50 requests/minute
+//	Rate: 500, Interval: time.Hour    // 500 requests/hour
+//
+// Widening Interval is how sustained rates below one request per second
+// are configured. Provider quotas stated per minute (as most LLM APIs
+// are) transcribe directly, with no per-second arithmetic:
+//
+//	// Provider tier documented as "50 RPM".
+//	limiter := ratelimit.New(ratelimit.Config{
+//	    Rate:     50,
+//	    Interval: time.Minute,
+//	    Burst:    10, // cap how much of the quota one spike may claim
+//	})
+//
+// Refill is continuous rather than stepped: the example above returns
+// roughly one token every 1.2s, not 50 tokens once a minute. Burst is the
+// bucket capacity and therefore the largest spike allowed; set it equal
+// to Rate for a strict quota, or lower to smooth traffic further.
+//
 // # Storage Backends
 //
 // The rate limiter uses a pluggable Store interface for state management.

--- a/ratelimit/example_test.go
+++ b/ratelimit/example_test.go
@@ -419,3 +419,30 @@ func Example_bucketCount() {
 	// Initial bucket count: 0
 	// After operations: 3 buckets
 }
+
+// Example_perMinuteQuota demonstrates transcribing a provider quota that is
+// documented per minute — the form used by most LLM and third-party APIs —
+// without converting it to a per-second figure. Interval carries the unit,
+// so sustained rates below one request per second need no fractional Rate.
+func Example_perMinuteQuota() {
+	// Provider tier documented as "50 RPM".
+	rl := ratelimit.New(ratelimit.Config{
+		Rate:     50,
+		Interval: time.Minute,
+		Burst:    10, // cap how much of the quota a single spike may claim
+	})
+	defer func() { _ = rl.Close() }()
+
+	ctx := context.Background()
+
+	// The bucket starts full at Burst, so a spike is capped at 10.
+	allowed := 0
+	for i := 0; i < 25; i++ {
+		if rl.Allow(ctx, "openai:gpt-5") {
+			allowed++
+		}
+	}
+
+	fmt.Printf("allowed in spike: %d\n", allowed)
+	// Output: allowed in spike: 10
+}

--- a/ratelimit/limiter_test.go
+++ b/ratelimit/limiter_test.go
@@ -3463,3 +3463,83 @@ func TestSanitizeLogKey(t *testing.T) {
 		}
 	})
 }
+
+// TestRateLimiterRatePerInterval pins the meaning of Rate as "tokens per
+// Interval" rather than "tokens per second". Widening Interval is how
+// sustained rates below one request per second are expressed, so quotas
+// published per minute or per hour need no fractional Rate.
+func TestRateLimiterRatePerInterval(t *testing.T) {
+	t.Parallel()
+
+	t.Run("burst bounds the initial spike regardless of interval", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name     string
+			interval time.Duration
+			rate     int
+			burst    int
+			want     int
+		}{
+			{name: "10 per second", interval: time.Second, rate: 10, burst: 10, want: 10},
+			{name: "50 per minute", interval: time.Minute, rate: 50, burst: 50, want: 50},
+			{name: "50 per minute, burst capped", interval: time.Minute, rate: 50, burst: 10, want: 10},
+			{name: "500 per hour", interval: time.Hour, rate: 500, burst: 500, want: 500},
+			{name: "1 per minute", interval: time.Minute, rate: 1, burst: 1, want: 1},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				limiter := New(Config{
+					Rate:     tt.rate,
+					Burst:    tt.burst,
+					Interval: tt.interval,
+				})
+				defer func() { _ = limiter.Close() }()
+
+				ctx := context.Background()
+				got := 0
+				for i := 0; i < tt.want*2+10; i++ {
+					if limiter.Allow(ctx, "quota-key") {
+						got++
+					}
+				}
+
+				if got != tt.want {
+					t.Errorf("allowed %d requests, want %d", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("sub-one-per-second sustained rate refills continuously", func(t *testing.T) {
+		t.Parallel()
+		// 50 requests/minute is 0.83/sec: one token roughly every 1.2s.
+		// An int Rate with Interval=time.Second could express neither 0.83
+		// nor a rounded-down alternative, so this is the case Interval exists for.
+		limiter := New(Config{
+			Rate:     50,
+			Burst:    1,
+			Interval: time.Minute,
+		})
+		defer func() { _ = limiter.Close() }()
+
+		ctx := context.Background()
+		if !limiter.Allow(ctx, "slow-key") {
+			t.Fatal("first request should drain the single-token bucket")
+		}
+		if limiter.Allow(ctx, "slow-key") {
+			t.Fatal("second request should be denied before any refill")
+		}
+
+		// Well short of a full Interval: refill is continuous, not stepped.
+		time.Sleep(1300 * time.Millisecond)
+
+		if !limiter.Allow(ctx, "slow-key") {
+			t.Error("a token should be back after ~1.2s at 50/minute")
+		}
+		if limiter.Allow(ctx, "slow-key") {
+			t.Error("only one token should have refilled")
+		}
+	})
+}


### PR DESCRIPTION
Addresses #66.

## What was wrong

**Not what the issue reported.** #66 states that `Rate` is "interpreted as requests
per second" and concludes a 50 RPM quota "cannot be expressed". That does not
reproduce: `ratelimit.Config` already has an `Interval` field, and `Rate` is
documented on the field itself as "the number of tokens added to the bucket **per
Interval**". The issue's own preferred fix —

```go
Rate    int           // requests per RatePer
RatePer time.Duration // defaults to time.Second when zero
```

— is the field that already ships, spelled `Interval`, with the same
default-to-`time.Second` behaviour it asks for.

What *is* real is the discoverability gap the issue's secondary section describes.
Every `Interval` in the package doc, in `docs/how-to-rate-limit.md`, and in the
`Rate` field's example was `time.Second`, so the pair reads as if seconds were
the only unit and `Rate` were fixed to req/sec.

## Evidence

The configuration the issue says is impossible works today, unchanged. Added as a
permanent test (`TestRateLimiterRatePerInterval`), which passes on `main` before
any change in this PR:

```
--- PASS: TestRateLimiterRatePerInterval/burst_bounds_the_initial_spike.../50_per_minute
--- PASS: TestRateLimiterRatePerInterval/sub-one-per-second_sustained_rate_refills_continuously (1.30s)
```

`Rate: 50, Interval: time.Minute, Burst: 50` admits exactly 50 requests, then
denies, then returns one token after ~1.2s — i.e. a true 0.83 req/sec sustained
rate, the figure the issue says is unreachable. Refill is continuous (`limiter.go`
scales elapsed time by `rateFloat/intervalNs`), so the minute is not a tumbling
step.

`Interval: time.Minute` is already used in shipped examples
(`ratelimit/example_test.go`, `Example_tieredRateLimit`, `Example_ipBasedRateLimit`)
— the capability was there, just never explained.

## What changed

Docs and tests only.

- `ratelimit/config.go` — `Rate` and `Interval` doc comments now state the
  relationship and give second/minute/hour examples; `Interval` notes that refill
  is continuous rather than stepped.
- `ratelimit/doc.go` — new "Expressing a Quota" section with the 50 RPM case.
- `docs/how-to-rate-limit.md` — new "Per-minute (and per-hour) quotas" recipe with
  a quota-to-config table.
- `ratelimit/example_test.go` — `Example_perMinuteQuota`.
- `ratelimit/limiter_test.go` — `TestRateLimiterRatePerInterval`, table-driven over
  units, plus the sub-1/sec continuous-refill case.

## On the API change the issue proposes

No API change is warranted, and I did not make one despite breaking changes now
being permitted for this fleet — compatibility is not forcing a worse design here,
because the design the issue asks for already exists.

- **Option 2 (`RatePer`)** is `Interval` renamed. Adding it would give the struct
  two fields meaning the same thing.
- **Option 1 (`Rate float64`)** would be a breaking change (and so, per Go semver
  on a v1 module, a `/v2` module path) that buys nothing: `Rate int` over a
  configurable `Interval` already expresses any rational rate, and more legibly
  than `Rate: 50.0/60.0`.

**Compatibility:** no API or behaviour change; `go.klarlabs.de/fortify` stays on
v1 and no consumer needs edits. `klarlabs-studio/roady` (on v1.8.1) is unaffected.

## How verified

`go build ./...`, `go vet ./...`, `go test ./...` all pass. `golangci-lint run
./ratelimit/...` reports 0 issues. The new example's `// Output:` is checked by
`go test`.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D