### PR TITLE
fix(retry)!: stop retrying ErrCircuitOpen by default

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -74,9 +74,35 @@ In priority order:
 2. `Config.NonRetryableErrors` — match via `errors.Is`; if matched, do not retry.
 3. `Config.RetryableErrors` — match via `errors.Is`; if matched, retry; if list set but no match, do not retry.
 4. `ferrors.IsRetryable(err)` — implements the `RetryableError` interface.
-5. Default: retry all errors.
+5. `ferrors.ErrCircuitOpen` — **not** retried. An open circuit is a decision, not a transient failure.
+6. Default: retry all other errors.
 
 Wrap an error to mark it retryable: `ferrors.AsRetryable(err)`.
+
+### Why `ErrCircuitOpen` is excluded from the default
+
+A breaker that has tripped Open has already concluded the downstream must be
+left alone. Retrying its rejection multiplies load on the rejection path and
+multiplies the latency before the caller sees an error that was known at the
+first attempt — during the incident the breaker exists to contain. Polly names
+the same rule: never configure retry to catch `BrokenCircuitException`.
+
+This only bites when retry sits *outside* the breaker (see
+[composition](how-to-compose.md)); fortify's recommended layering puts retry
+inside, where `ErrCircuitOpen` never reaches it. The exclusion makes the
+inverted layering safe rather than silently wrong.
+
+`ferrors.ErrBulkheadFull` and `ferrors.ErrRateLimitExceeded` are deliberately
+*not* excluded — both describe a queue that drains on its own, so backing off
+and retrying stays a defensible policy. List them in `NonRetryableErrors` if
+your workload cannot wait.
+
+To retry an open circuit anyway, say so explicitly — rule 1, 3, or 4:
+
+```go
+retry.Config{IsRetryable: func(error) bool { return true }}
+retry.Config{RetryableErrors: []error{ferrors.ErrCircuitOpen}}
+```
 
 ### When **not** to retry
 

--- a/middleware/chain_test.go
+++ b/middleware/chain_test.go
@@ -9,6 +9,7 @@ import (
 	"go.klarlabs.de/fortify/bulkhead"
 	"go.klarlabs.de/fortify/circuitbreaker"
 	"go.klarlabs.de/fortify/fallback"
+	"go.klarlabs.de/fortify/ferrors"
 	"go.klarlabs.de/fortify/ratelimit"
 	"go.klarlabs.de/fortify/retry"
 	"go.klarlabs.de/fortify/timeout"
@@ -176,5 +177,114 @@ func TestChainWithFallback(t *testing.T) {
 	}
 	if out != "recovered" {
 		t.Errorf("out = %q, want \"recovered\"", out)
+	}
+}
+
+// TestRetryOutsideBreakerDoesNotStormAnOpenCircuit covers the composition
+// hazard in #69.
+//
+// With retry outside the circuit breaker — the layering Resilience4j and
+// Polly recommend, and one users reach for even though fortify's own
+// guidance puts retry inside — each retry attempt is a separate
+// cb.Execute. Under a "retry everything" default, every logical call made
+// while the breaker is Open therefore costs MaxAttempts rejections spaced
+// by backoff, instead of the single rejection the breaker intended. That
+// multiplies load on the rejection path and multiplies the latency before
+// the caller sees an error already known at the first attempt — during the
+// incident the breaker exists to contain.
+func TestRetryOutsideBreakerDoesNotStormAnOpenCircuit(t *testing.T) {
+	downstream := errors.New("downstream exploded")
+
+	const backoff = 50 * time.Millisecond
+
+	cb := circuitbreaker.New[int](circuitbreaker.Config{
+		Timeout:     time.Minute, // stay Open for the whole test
+		ReadyToTrip: func(circuitbreaker.Counts) bool { return true },
+	})
+	defer func() { _ = cb.Close() }()
+
+	// Trip the breaker with a single failure.
+	if _, err := cb.Execute(context.Background(), func(context.Context) (int, error) {
+		return 0, downstream
+	}); !errors.Is(err, downstream) {
+		t.Fatalf("setup: err = %v, want %v", err, downstream)
+	}
+	if got := cb.State(); got != circuitbreaker.StateOpen {
+		t.Fatalf("setup: breaker state = %s, want open", got)
+	}
+
+	// Retry added first makes retry the OUTER layer.
+	retries := 0
+	chain := New[int]().
+		WithRetry(retry.New[int](retry.Config{
+			MaxAttempts:   3,
+			InitialDelay:  backoff,
+			BackoffPolicy: retry.BackoffConstant,
+			OnRetry:       func(int, error) { retries++ },
+		})).
+		WithCircuitBreaker(cb)
+
+	start := time.Now()
+	_, err := chain.Execute(context.Background(), func(context.Context) (int, error) {
+		t.Error("operation ran while the circuit was open")
+		return 0, nil
+	})
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ferrors.ErrCircuitOpen) {
+		t.Fatalf("err = %v, want ErrCircuitOpen", err)
+	}
+	if retries != 0 {
+		t.Errorf("retry made %d further attempts against an open circuit, want 0", retries)
+	}
+	// Two extra attempts would have cost 2*backoff in pure waiting.
+	if elapsed >= backoff {
+		t.Errorf("call took %s against an open circuit; a rejection known at attempt 1 should return immediately", elapsed)
+	}
+}
+
+// TestRetryInsideBreakerObservesOneOutcomePerCall records the layering
+// fortify recommends: the breaker added first is the outer layer, so it
+// sees a single outcome per logical call and a blip that retry recovers
+// from is counted as one success rather than several failures.
+func TestRetryInsideBreakerObservesOneOutcomePerCall(t *testing.T) {
+	transient := errors.New("transient blip")
+
+	cb := circuitbreaker.New[int](circuitbreaker.Config{
+		Timeout:     time.Minute,
+		ReadyToTrip: func(c circuitbreaker.Counts) bool { return c.ConsecutiveFailures >= 2 },
+	})
+	defer func() { _ = cb.Close() }()
+
+	// Breaker added first => breaker outermost, retry inside it.
+	chain := New[int]().
+		WithCircuitBreaker(cb).
+		WithRetry(retry.New[int](retry.Config{
+			MaxAttempts:  3,
+			InitialDelay: time.Millisecond,
+		}))
+
+	// Two logical calls, each failing twice then succeeding. With retry
+	// inside, that is two successes; with retry outside it would be four
+	// consecutive failures and a tripped circuit.
+	for call := 0; call < 2; call++ {
+		attempt := 0
+		result, err := chain.Execute(context.Background(), func(context.Context) (int, error) {
+			attempt++
+			if attempt < 3 {
+				return 0, transient
+			}
+			return 42, nil
+		})
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", call, err)
+		}
+		if result != 42 {
+			t.Errorf("call %d: result = %d, want 42", call, result)
+		}
+	}
+
+	if got := cb.State(); got != circuitbreaker.StateClosed {
+		t.Errorf("breaker state = %s, want closed: recovered blips must not trip it", got)
 	}
 }

--- a/retry/circuit_open_test.go
+++ b/retry/circuit_open_test.go
@@ -1,0 +1,168 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/fortify/ferrors"
+)
+
+// TestCircuitOpenNotRetryableByDefault pins the classification of
+// ferrors.ErrCircuitOpen.
+//
+// An open circuit is a decision, not a transient failure: the breaker has
+// already concluded the downstream must be left alone. Retrying it
+// multiplies load on the rejection path and multiplies the latency a
+// caller waits before receiving an error that was known at the first
+// attempt. Polly names the same trap — "never configure retry to catch
+// BrokenCircuitException". So the default classification, which retries
+// every other error, must exclude it.
+//
+// Explicit classification still wins: a caller who genuinely wants to
+// retry an open circuit says so via IsRetryable, RetryableErrors, or
+// ferrors.AsRetryable.
+func TestCircuitOpenNotRetryableByDefault(t *testing.T) {
+	t.Parallel()
+
+	// structured is the error a real breaker returns. It unwraps to
+	// ferrors.ErrCircuitOpen, so matching must see through it.
+	structured := &ferrors.CircuitOpenError{
+		State:      "open",
+		RetryAfter: 30 * time.Second,
+	}
+
+	tests := []struct {
+		name         string
+		config       Config
+		err          error
+		wantAttempts int
+	}{
+		{
+			name:         "default config does not retry the bare sentinel",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          ferrors.ErrCircuitOpen,
+			wantAttempts: 1,
+		},
+		{
+			name:         "default config does not retry the structured error",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          structured,
+			wantAttempts: 1,
+		},
+		{
+			name:         "default config does not retry a wrapped circuit-open error",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          fmt.Errorf("calling users service: %w", ferrors.ErrCircuitOpen),
+			wantAttempts: 1,
+		},
+		{
+			name: "an unrelated NonRetryableErrors entry does not re-enable it",
+			config: Config{
+				MaxAttempts:        3,
+				InitialDelay:       time.Millisecond,
+				NonRetryableErrors: []error{errors.New("something else")},
+			},
+			err:          ferrors.ErrCircuitOpen,
+			wantAttempts: 1,
+		},
+		{
+			name:         "ordinary errors stay retryable",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          errors.New("connection reset by peer"),
+			wantAttempts: 3,
+		},
+		{
+			name:         "bulkhead rejections stay retryable",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          ferrors.ErrBulkheadFull,
+			wantAttempts: 3,
+		},
+		{
+			name:         "rate-limit rejections stay retryable",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          ferrors.ErrRateLimitExceeded,
+			wantAttempts: 3,
+		},
+		{
+			name: "IsRetryable overrides the default",
+			config: Config{
+				MaxAttempts:  3,
+				InitialDelay: time.Millisecond,
+				IsRetryable:  func(error) bool { return true },
+			},
+			err:          ferrors.ErrCircuitOpen,
+			wantAttempts: 3,
+		},
+		{
+			name: "listing it in RetryableErrors opts back in",
+			config: Config{
+				MaxAttempts:     3,
+				InitialDelay:    time.Millisecond,
+				RetryableErrors: []error{ferrors.ErrCircuitOpen},
+			},
+			err:          ferrors.ErrCircuitOpen,
+			wantAttempts: 3,
+		},
+		{
+			name:         "ferrors.AsRetryable opts back in",
+			config:       Config{MaxAttempts: 3, InitialDelay: time.Millisecond},
+			err:          ferrors.AsRetryable(ferrors.ErrCircuitOpen),
+			wantAttempts: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := New[int](tt.config)
+
+			attempts := 0
+			_, err := r.Execute(context.Background(), func(ctx context.Context) (int, error) {
+				attempts++
+				return 0, tt.err
+			})
+
+			if attempts != tt.wantAttempts {
+				t.Errorf("attempts = %d, want %d", attempts, tt.wantAttempts)
+			}
+			if err == nil {
+				t.Error("expected the final error to be returned, got nil")
+			}
+		})
+	}
+}
+
+// TestCircuitOpenRejectionIsReturnedVerbatim checks that declining to retry
+// does not swallow the breaker's structured error: callers still get the
+// state and retry-after hint back through errors.As.
+func TestCircuitOpenRejectionIsReturnedVerbatim(t *testing.T) {
+	t.Parallel()
+
+	want := &ferrors.CircuitOpenError{
+		Name:       "users-api",
+		State:      "open",
+		RetryAfter: 12 * time.Second,
+	}
+
+	r := New[int](Config{MaxAttempts: 3, InitialDelay: time.Millisecond})
+
+	_, err := r.Execute(context.Background(), func(ctx context.Context) (int, error) {
+		return 0, want
+	})
+
+	if !errors.Is(err, ferrors.ErrCircuitOpen) {
+		t.Fatalf("errors.Is(err, ErrCircuitOpen) = false, err = %v", err)
+	}
+
+	var got *ferrors.CircuitOpenError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As did not recover *CircuitOpenError from %v", err)
+	}
+	if got.Name != want.Name || got.RetryAfter != want.RetryAfter {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}

--- a/retry/config.go
+++ b/retry/config.go
@@ -7,6 +7,22 @@ import (
 
 // Config holds the configuration for a Retry instance.
 //
+// # Default retryability
+//
+// With no classification configured, every error is retried except
+// ferrors.ErrCircuitOpen. An open circuit is a deliberate rejection
+// rather than a transient failure — the breaker has already decided the
+// downstream must be left alone — so retrying it multiplies load on the
+// rejection path and multiplies the latency before the caller sees an
+// error that was known at the first attempt.
+//
+// ferrors.ErrBulkheadFull and ferrors.ErrRateLimitExceeded remain
+// retryable by default: both describe a queue that drains on its own.
+//
+// To retry an open circuit anyway, opt in explicitly with IsRetryable,
+// by listing ferrors.ErrCircuitOpen in RetryableErrors, or by wrapping
+// with ferrors.AsRetryable.
+//
 // Field alignment optimization is intentionally disabled for this public API struct because:
 // 1. This is a user-facing configuration struct that appears in documentation
 // 2. Fields are logically grouped (errors, callbacks, timing, policy) for better API comprehension
@@ -18,7 +34,10 @@ import (
 type Config struct {
 	// RetryableErrors is a list of errors that should trigger a retry.
 	// Uses errors.Is for comparison. If both RetryableErrors and NonRetryableErrors
-	// are nil/empty, and IsRetryable is nil, all errors are considered retryable.
+	// are nil/empty, and IsRetryable is nil, all errors are considered retryable
+	// except ferrors.ErrCircuitOpen (see the "Default retryability" section above).
+	//
+	// Listing ferrors.ErrCircuitOpen here opts back into retrying it.
 	RetryableErrors []error
 
 	// NonRetryableErrors is a list of errors that should NOT trigger a retry.

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -17,6 +17,14 @@
 //	user, err := r.Execute(ctx, func(ctx context.Context) (*User, error) {
 //	    return fetchUser(ctx, userID)
 //	})
+//
+// # Retryability
+//
+// With no classification configured, every error is retried except
+// ferrors.ErrCircuitOpen: an open circuit is a decision the breaker has
+// already made, not a transient failure, so retrying it only adds load
+// and latency to the rejection path. See Config for the full precedence
+// order and for how to opt back in.
 package retry
 
 import (
@@ -177,9 +185,25 @@ func (r *retry[T]) isRetryable(err error) bool {
 		return false
 	}
 
-	// Check if error implements RetryableError interface
+	// Check if error implements RetryableError interface.
+	// An explicit ferrors.AsRetryable marking is a deliberate caller
+	// signal, so it outranks the control-flow default below.
 	if ferrors.IsRetryable(err) {
 		return true
+	}
+
+	// Fortify's own control-flow rejections are decisions, not transient
+	// failures. An open circuit has already concluded the downstream must
+	// be left alone; retrying multiplies load on the rejection path and
+	// multiplies the latency before the caller sees an error that was
+	// known at the first attempt. Excluded from the permissive default so
+	// that composing retry outside a breaker is not a silent trap.
+	//
+	// Deliberately narrow: ErrBulkheadFull and ErrRateLimitExceeded are
+	// also rejections, but they describe a queue that drains on its own,
+	// so backing off and retrying remains a defensible policy.
+	if errors.Is(err, ferrors.ErrCircuitOpen) {
+		return false
 	}
 
 	// Default: retry all errors if no classification is configured


### PR DESCRIPTION
Closes #69.

> **Breaking change, shipping as a MINOR bump on the v1 module path (v1.9.0).**
> This is a deliberate semver deviation, chosen with the owner, not an oversight.
> The module path stays `go.klarlabs.de/fortify` — no `/v2`. Migration note below.

## What was wrong

Reproduced. `retry.Config` documents its default as "all errors are considered
retryable", and `isRetryable` ended with an unconditional `return true`.
`ferrors.ErrCircuitOpen` is an error, so the default retried it.

An open circuit is a *decision*, not a transient failure — the breaker has
already concluded the downstream must be left alone. Retrying its rejection
multiplies load on the rejection path and multiplies the latency before the
caller sees an error that was known at attempt 1, during exactly the incident
the breaker exists to contain. Polly states the rule outright: never configure
retry to catch `BrokenCircuitException`.

## Evidence

`TestRetryOutsideBreakerDoesNotStormAnOpenCircuit` (new, in `middleware`)
composes fortify's own retry outside fortify's own breaker and measures one
logical call against the tripped circuit. On `main`, before the fix:

```
--- FAIL: TestRetryOutsideBreakerDoesNotStormAnOpenCircuit (0.10s)
    chain_test.go:238: retry made 2 further attempts against an open circuit, want 0
    chain_test.go:242: call took 103.232041ms against an open circuit;
                       a rejection known at attempt 1 should return immediately
```

Three rejections and 103ms of pure backoff, for an answer available in
microseconds. `TestCircuitOpenNotRetryableByDefault` (new, in `retry`) fails the
same way at the unit level — `attempts = 3, want 1` for the bare sentinel, the
structured `*ferrors.CircuitOpenError`, and a `%w`-wrapped circuit-open error.

Both pass after the change; the whole suite passes.

## What changed

One behavioural change, in `retry.isRetryable`, on the **default path only**:

```go
// Fortify's own control-flow rejections are decisions, not transient failures.
if errors.Is(err, ferrors.ErrCircuitOpen) {
    return false
}

// Default: retry all errors if no classification is configured
return true
```

Placed *after* the `ferrors.IsRetryable` check, so an explicit
`ferrors.AsRetryable` marking still outranks it. Explicit classification wins in
every form, which is why **no new API was needed** for the escape hatch.

Deliberately narrow: `ErrBulkheadFull` and `ErrRateLimitExceeded` stay retryable.
Both are also rejections, but they describe a queue that drains on its own, so
backing off and retrying remains a defensible policy. Pinned by tests.

Docs updated at `retry.Config` (new "Default retryability" section), the `retry`
package doc, `RetryableErrors`, and the precedence list in `docs/concepts.md`
(which said "5. Default: retry all errors" and would otherwise have gone stale).

Presets need no edit: `HTTPClient` and `LLMCall` already excluded `ErrCircuitOpen`
via `IsRetryable`; `DatabaseQuery` and `RPCDownstream` use the default and so
inherit the fix, closing an inconsistency between the four.

## Migration note

**What breaks:** `retry.Retry.Execute` no longer retries an error matching
`ferrors.ErrCircuitOpen` when the `Config` sets neither `IsRetryable` nor a
`RetryableErrors` allowlist. Previously it retried up to `MaxAttempts`.

**Who is affected:** only callers that (a) use the default classification and
(b) feed retry an error that unwraps to `ErrCircuitOpen` — i.e. retry composed
outside a circuit breaker. No signature, name, or type changed; everything still
compiles. This is a behaviour change only.

**Before / after** — to keep the old behaviour, state it explicitly:

```go
// before: open circuits were retried implicitly
r := retry.New[T](retry.Config{MaxAttempts: 3})

// after: opt back in, either way
r := retry.New[T](retry.Config{
    MaxAttempts: 3,
    IsRetryable: func(error) bool { return true },
})
r := retry.New[T](retry.Config{
    MaxAttempts:     3,
    RetryableErrors: []error{ferrors.ErrCircuitOpen},
})
```

Most callers want the new behaviour and should change nothing.

**Known consumer — `klarlabs-studio/roady` (pins v1.8.1): no changes needed.**
It constructs `retry.Config` in two places, `pkg/storage/filesystem.go:72` and
`pkg/sdk/client.go:29`, both with only `MaxAttempts`/`InitialDelay`/`BackoffPolicy`.
Both wrap operations (filesystem I/O, MCP transport calls) that never produce
`ErrCircuitOpen`, and roady does not import `fortify/circuitbreaker` at all — its
only fortify import is `fortify/retry`. Behaviour there is unchanged.

## How verified

`go build ./...`, `go vet ./...`, `go test ./...` all pass.
`golangci-lint run ./retry/... ./middleware/...` reports 0 issues.
Tests were written first and confirmed red before the one-hunk fix.

## Related

#67 covers the layering documentation this is the companion to. Kept separate:
that one is doc-only and touches `middleware`, this one is a behaviour change in
`retry`. The cross-reference at `Chain.WithRetry` lands with #67.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D