### PR TITLE
docs(middleware): state the layering rule and fix the timeout contradiction

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -183,6 +183,16 @@ Reacts to rising latency *before* failures appear. Slightly more overhead per ca
 
 ## Composition order
 
+**In `middleware.Chain`, the middleware added first is the outermost layer.**
+`New().WithCircuitBreaker(cb).WithRetry(r)` therefore places retry *inside* the
+breaker.
+
 Outer-to-inner: `Bulkhead → RateLimit → CircuitBreaker → Retry → Timeout → operation`.
 
-Rationale and edge cases (retry inside CB vs outside, etc.) in the [composition guide](how-to-compose.md).
+The two placements that most often surprise people:
+
+- **Retry inside the circuit breaker.** The breaker then observes one outcome per logical call, so a blip retry recovers from counts as a success. Outside, each attempt is its own observation and a recovered blip can trip the circuit.
+- **Timeout innermost.** Bounds each attempt rather than the whole retry sequence. Worst-case chain latency is therefore about `MaxAttempts × timeout` plus backoff; use a parent context deadline for a hard total ceiling.
+
+Rationale, the arithmetic behind `FailuresToTrip` vs `MaxAttempts`, and the
+common mis-orderings are in the [composition guide](how-to-compose.md).

--- a/docs/how-to-compose.md
+++ b/docs/how-to-compose.md
@@ -2,32 +2,67 @@
 
 Patterns are most useful in combination. Fortify's `middleware.Chain` is a fluent builder for layering them in the right order.
 
+## The layering rule
+
+**The middleware added first is the outermost layer.** Each subsequent `With…`
+call nests one level closer to the operation, which runs innermost. A chain
+built as A, B, C executes `A → B → C → operation → C → B → A`.
+
+This is worth stating plainly because "applied in the order they were added"
+reads both ways, and getting it backwards is silent: the chain still compiles,
+still returns correct results while the downstream is healthy, and only
+misbehaves under load — as circuits that trip when they should not.
+
 ## Recommended chain
 
 ```go
 import "go.klarlabs.de/fortify/middleware"
 
 chain := middleware.New[Response]().
-    WithBulkhead(bh).                      // outermost
+    WithBulkhead(bh).                       // outermost
     WithRateLimit(rl, "user-key").
-    WithTimeout(tm, 5*time.Second).
     WithCircuitBreaker(cb).
-    WithRetry(r)                            // innermost (closest to operation)
+    WithRetry(r).
+    WithTimeout(tm, 5*time.Second)          // innermost (closest to operation)
 
 result, err := chain.Execute(ctx, func(ctx context.Context) (Response, error) {
     return makeRequest(ctx)
 })
 ```
 
+Outer → inner: `Bulkhead → RateLimit → CircuitBreaker → Retry → Timeout → operation`.
+This is the layering the shipped presets (`HTTPClient`, `DatabaseQuery`,
+`RPCDownstream`, `LLMCall`) already apply — prefer one of those when it fits.
+
 ## Why this order
 
 Reading outer → inner:
 
 1. **Bulkhead first** — shed load before doing any other work. Cheapest rejection.
-2. **Rate limit next** — enforce quota before consuming downstream budget.
-3. **Timeout outside circuit breaker** — guarantees a deadline even if the breaker is in Half-Open and stalls on a trial request.
-4. **Circuit breaker before retry** — retry on transient failure, but if the breaker has tripped Open, fail fast instead of retrying through a known-bad dependency.
-5. **Retry innermost** — only retries the operation itself, not the surrounding patterns. A retry won't trigger a second bulkhead or rate-limit charge.
+2. **Rate limit next** — enforce quota before consuming downstream budget. Above the breaker, so that blocking for a quota slot is not charged against an attempt's timeout budget.
+3. **Circuit breaker before retry** — the breaker sees one outcome per *logical* call, so a transient failure that retry recovers from is recorded as a success, not as several failures.
+4. **Retry inside the breaker** — retries re-run only the operation, not the surrounding patterns. A retry won't take a second bulkhead slot or a second rate-limit token.
+5. **Timeout innermost** — bounds each individual attempt rather than the whole retry sequence, so a slow first attempt cannot consume the budget the remaining attempts need.
+
+### What timeout innermost costs you
+
+Worst-case chain latency becomes roughly `MaxAttempts × timeout` plus accumulated
+backoff, not `timeout`. When the caller needs a hard ceiling on the whole
+operation, put a deadline on the context you pass to `Execute`; `timeout.Execute`
+detects a nearer parent deadline and propagates the parent's error verbatim.
+
+The alternative — timeout *outside* the breaker — buys a guaranteed deadline even
+if a Half-Open trial request stalls, at the cost of letting one slow attempt eat
+the budget the retries needed. Fortify's presets take the per-attempt side of
+that trade.
+
+### Retry and `ErrCircuitOpen`
+
+With retry inside the breaker, `ferrors.ErrCircuitOpen` never reaches retry: the
+breaker rejects before the retry layer is entered. If you invert the order, check
+how your `retry.Config` classifies it — retrying a rejection the breaker issued
+on purpose only adds load and latency to a decision already made. See the
+[retryability rules](concepts.md#retryability-rules).
 
 ## Order pitfalls
 
@@ -40,6 +75,14 @@ chain := middleware.New[Response]().
 ```
 
 Each retry is a separate `cb.Execute` call. A flaky downstream causes the breaker to trip on the *retries*, not the originating failure rate.
+
+Concretely, with `FailuresToTrip: 5` and `MaxAttempts: 3`: in the recommended
+order two recovered blips are two successes and nothing happens. Inverted, they
+are six consecutive failures and the circuit opens on a downstream that is in
+fact healthy. Same config, opposite outcome — and `MaxAttempts` and
+`FailuresToTrip` are chosen in different files by different people, so the
+coupling is invisible unless you already know the layering. Any
+`FailuresToTrip <= MaxAttempts` opens the circuit on a single flaky call.
 
 ### Bulkhead inside retry (wrong)
 

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -5,13 +5,56 @@
 // rate limiters, timeouts, and bulkheads in any order, creating flexible
 // and powerful resilience strategies.
 //
-// Example usage:
+// # Layering order
+//
+// The middleware added FIRST is the OUTERMOST layer. Each subsequent
+// With… call nests one level closer to the operation, which runs
+// innermost.
+//
+//	middleware.New[T]().
+//	    WithBulkhead(bh).       // outermost: wraps everything below
+//	    WithRateLimit(rl, key).
+//	    WithCircuitBreaker(cb).
+//	    WithRetry(r).
+//	    WithTimeout(tm, d)      // innermost: wraps only the operation
+//
+// Order is not a stylistic choice — it changes production behaviour, and
+// it does so silently. The chain compiles and behaves plausibly whichever
+// way round it is built, so a mistake surfaces only under load, as
+// circuits that trip when they should not.
+//
+// The consequential pair is retry and the circuit breaker:
+//
+//   - WithCircuitBreaker(cb).WithRetry(r) puts retry INSIDE the breaker.
+//     The breaker observes one outcome per logical call, so a transient
+//     failure that retry recovers from is recorded as a success. This is
+//     the recommended arrangement.
+//   - WithRetry(r).WithCircuitBreaker(cb) puts retry OUTSIDE the breaker.
+//     Every attempt becomes a separate breaker observation, so a single
+//     recovered blip can contribute MaxAttempts consecutive failures and
+//     trip a circuit protecting a downstream that is in fact healthy.
+//
+// With FailuresToTrip: 5 and MaxAttempts: 3, two recovered blips open the
+// circuit in the second arrangement and nothing happens in the first.
+//
+// Two further placements are worth stating:
+//
+//   - Timeout innermost bounds each attempt rather than the whole retry
+//     sequence, so a slow first attempt cannot consume the budget the
+//     remaining attempts need.
+//   - Rate limit above the breaker keeps the wait for a quota slot from
+//     being charged against an attempt's timeout budget.
+//
+// See docs/how-to-compose.md for the full rationale and the common
+// mis-orderings. The Presets (HTTPClient, DatabaseQuery, RPCDownstream,
+// LLMCall) apply this layering already; prefer one of those when it fits.
+//
+// # Example
 //
 //	chain := middleware.New[Response]().
 //	    WithCircuitBreaker(cb).
 //	    WithRetry(retry).
-//	    WithTimeout(timeout, 5*time.Second).
-//	    WithRateLimit(limiter, "user-123")
+//	    WithTimeout(timeout, 5*time.Second)
 //
 //	response, err := chain.Execute(ctx, func(ctx context.Context) (Response, error) {
 //	    return apiClient.Call(ctx)
@@ -49,6 +92,11 @@ func New[T any]() *Chain[T] {
 }
 
 // WithCircuitBreaker adds a circuit breaker to the middleware chain.
+// Place it OUTSIDE retry (i.e., add it before WithRetry) so the breaker
+// observes one outcome per logical call and a transient failure that
+// retry recovers from is recorded as a success. Adding it after WithRetry
+// makes every attempt a separate observation, so a recovered blip can
+// trip a circuit protecting a healthy downstream.
 func (c *Chain[T]) WithCircuitBreaker(cb circuitbreaker.CircuitBreaker[T]) *Chain[T] {
 	middleware := func(next func(context.Context) (T, error)) func(context.Context) (T, error) {
 		return func(ctx context.Context) (T, error) {
@@ -59,7 +107,16 @@ func (c *Chain[T]) WithCircuitBreaker(cb circuitbreaker.CircuitBreaker[T]) *Chai
 	return c
 }
 
-// WithRetry adds retry logic to the middleware chain.
+// WithRetry adds retry logic to the middleware chain. Place it INSIDE the
+// circuit breaker (i.e., add it after WithCircuitBreaker) and outside the
+// timeout, so retries re-run only the operation and each attempt carries
+// its own deadline.
+//
+// If you do invert it, check how your retry.Config classifies
+// ferrors.ErrCircuitOpen: with retry outside the breaker, every logical
+// call made while the circuit is Open passes the breaker's rejection back
+// to retry, and retrying that only adds load and latency to a decision
+// already made. See retry.Config.
 func (c *Chain[T]) WithRetry(r retry.Retry[T]) *Chain[T] {
 	middleware := func(next func(context.Context) (T, error)) func(context.Context) (T, error) {
 		return func(ctx context.Context) (T, error) {
@@ -72,6 +129,11 @@ func (c *Chain[T]) WithRetry(r retry.Retry[T]) *Chain[T] {
 
 // WithRateLimit adds rate limiting to the middleware chain.
 // The key parameter identifies the rate limit bucket (e.g., user ID, IP address).
+//
+// Place it above the circuit breaker (i.e., add it before
+// WithCircuitBreaker) and outside any timeout: this middleware blocks in
+// rl.Wait until a token is free, and inside a timeout that wait is
+// charged against the attempt's deadline rather than the operation.
 func (c *Chain[T]) WithRateLimit(rl ratelimit.RateLimiter, key string) *Chain[T] {
 	middleware := func(next func(context.Context) (T, error)) func(context.Context) (T, error) {
 		return func(ctx context.Context) (T, error) {
@@ -86,7 +148,14 @@ func (c *Chain[T]) WithRateLimit(rl ratelimit.RateLimiter, key string) *Chain[T]
 	return c
 }
 
-// WithTimeout adds timeout enforcement to the middleware chain.
+// WithTimeout adds timeout enforcement to the middleware chain. Place it
+// innermost (i.e., add it last) so duration bounds each individual
+// attempt rather than the whole retry sequence — otherwise a slow first
+// attempt can consume the budget the remaining attempts need.
+//
+// Worst-case latency for the chain is therefore roughly
+// MaxAttempts × duration plus accumulated backoff, not duration. Bound
+// the total with a parent context deadline when that matters.
 func (c *Chain[T]) WithTimeout(tm timeout.Timeout[T], duration time.Duration) *Chain[T] {
 	middleware := func(next func(context.Context) (T, error)) func(context.Context) (T, error) {
 		return func(ctx context.Context) (T, error) {
@@ -97,7 +166,10 @@ func (c *Chain[T]) WithTimeout(tm timeout.Timeout[T], duration time.Duration) *C
 	return c
 }
 
-// WithBulkhead adds concurrency limiting to the middleware chain.
+// WithBulkhead adds concurrency limiting to the middleware chain. Place
+// it outermost among the rejection patterns (i.e., add it first, or just
+// after WithAdaptive) so saturation is shed before any other work is
+// done, and outside WithRetry so retries do not each queue for a new slot.
 func (c *Chain[T]) WithBulkhead(bh bulkhead.Bulkhead[T]) *Chain[T] {
 	middleware := func(next func(context.Context) (T, error)) func(context.Context) (T, error) {
 		return func(ctx context.Context) (T, error) {
@@ -174,7 +246,13 @@ func (c *Chain[T]) WithFallback(fb fallback.Fallback[T]) *Chain[T] {
 }
 
 // Execute runs the given function through all middlewares in the chain.
-// Middlewares are applied in the order they were added to the chain.
+//
+// The middleware added first is the outermost layer: it is entered first
+// and exited last, and it wraps every middleware added after it. fn runs
+// innermost. A chain built as A, B, C therefore executes
+// A → B → C → fn → C → B → A.
+//
+// See the package doc for why the order matters.
 func (c *Chain[T]) Execute(ctx context.Context, fn func(context.Context) (T, error)) (T, error) {
 	// Build the chain from right to left
 	next := fn

--- a/middleware/layering_test.go
+++ b/middleware/layering_test.go
@@ -1,0 +1,163 @@
+package middleware
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/fortify/bulkhead"
+	"go.klarlabs.de/fortify/circuitbreaker"
+	"go.klarlabs.de/fortify/ratelimit"
+	"go.klarlabs.de/fortify/retry"
+	"go.klarlabs.de/fortify/timeout"
+)
+
+// TestChainLayeringOrder pins the rule the middleware package documents:
+// the middleware added first is the OUTERMOST layer.
+//
+// The rule is load-bearing rather than cosmetic. It decides whether retry
+// sits inside the circuit breaker (breaker sees one outcome per logical
+// call) or outside it (every attempt is a separate breaker observation, so
+// a recovered blip can trip the circuit). Same config, opposite production
+// behaviour, and nothing at the call site shows which you got — so the
+// build order in Chain.Execute is worth a test, not just a sentence.
+func TestChainLayeringOrder(t *testing.T) {
+	t.Parallel()
+
+	// tracer records entry and exit around the layer it wraps.
+	tracer := func(name string, log *[]string) Middleware[int] {
+		return func(next func(context.Context) (int, error)) func(context.Context) (int, error) {
+			return func(ctx context.Context) (int, error) {
+				*log = append(*log, "enter:"+name)
+				result, err := next(ctx)
+				*log = append(*log, "exit:"+name)
+				return result, err
+			}
+		}
+	}
+
+	t.Run("first added wraps the rest", func(t *testing.T) {
+		t.Parallel()
+
+		var log []string
+		c := New[int]()
+		c.middlewares = append(c.middlewares,
+			tracer("first", &log),
+			tracer("second", &log),
+			tracer("third", &log),
+		)
+
+		if _, err := c.Execute(context.Background(), func(context.Context) (int, error) {
+			log = append(log, "operation")
+			return 42, nil
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []string{
+			"enter:first", "enter:second", "enter:third",
+			"operation",
+			"exit:third", "exit:second", "exit:first",
+		}
+		if strings.Join(log, ",") != strings.Join(want, ",") {
+			t.Errorf("order:\n got %v\nwant %v", log, want)
+		}
+	})
+
+	t.Run("single middleware still wraps the operation", func(t *testing.T) {
+		t.Parallel()
+
+		var log []string
+		c := New[int]()
+		c.middlewares = append(c.middlewares, tracer("only", &log))
+
+		if _, err := c.Execute(context.Background(), func(context.Context) (int, error) {
+			log = append(log, "operation")
+			return 1, nil
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []string{"enter:only", "operation", "exit:only"}
+		if strings.Join(log, ",") != strings.Join(want, ",") {
+			t.Errorf("order:\n got %v\nwant %v", log, want)
+		}
+	})
+
+	t.Run("empty chain runs the operation directly", func(t *testing.T) {
+		t.Parallel()
+
+		var log []string
+		if _, err := New[int]().Execute(context.Background(), func(context.Context) (int, error) {
+			log = append(log, "operation")
+			return 1, nil
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(log) != 1 || log[0] != "operation" {
+			t.Errorf("log = %v, want [operation]", log)
+		}
+	})
+}
+
+// TestCanonicalStackLayering pins the outer-to-inner order of the canonical
+// stack documented in the package doc and docs/how-to-compose.md:
+//
+//	Bulkhead → RateLimit → CircuitBreaker → Retry → Timeout → operation
+//
+// This guards the documented recipe against silent drift: if the build
+// order in Execute is ever reversed, the arrow diagram in the docs would
+// still read plausibly while describing the opposite chain.
+func TestCanonicalStackLayering(t *testing.T) {
+	t.Parallel()
+
+	rl := ratelimit.New(ratelimit.Config{Rate: 100, Burst: 100, Interval: time.Second})
+	defer func() { _ = rl.Close() }()
+
+	cb := circuitbreaker.New[int](circuitbreaker.Config{Timeout: time.Minute})
+	defer func() { _ = cb.Close() }()
+
+	chain := New[int]().
+		WithBulkhead(bulkhead.New[int](bulkhead.Config{MaxConcurrent: 4})).
+		WithRateLimit(rl, "layering-key").
+		WithCircuitBreaker(cb).
+		WithRetry(retry.New[int](retry.Config{MaxAttempts: 3, InitialDelay: time.Millisecond})).
+		WithTimeout(timeout.New[int](timeout.Config{DefaultTimeout: time.Second}), time.Second)
+
+	if got := len(chain.middlewares); got != 5 {
+		t.Fatalf("len(middlewares) = %d, want 5", got)
+	}
+
+	// Timeout is innermost, so each attempt gets its own deadline rather
+	// than the whole retry sequence sharing one. Two failures then a
+	// success must therefore complete, not exhaust a shared budget.
+	attempts := 0
+	result, err := chain.Execute(context.Background(), func(ctx context.Context) (int, error) {
+		attempts++
+		if attempts < 3 {
+			return 0, context.DeadlineExceeded
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Error("innermost timeout did not set a deadline on the operation context")
+		} else if time.Until(deadline) <= 0 {
+			t.Error("operation context deadline already elapsed")
+		}
+		return 7, nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != 7 {
+		t.Errorf("result = %d, want 7", result)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+	if got := cb.State(); got != circuitbreaker.StateClosed {
+		t.Errorf("breaker state = %s, want closed: retry is inside the breaker, so the recovered call is one success", got)
+	}
+}

--- a/middleware/presets.go
+++ b/middleware/presets.go
@@ -18,6 +18,15 @@ import (
 // resilience shapes. They exist so you don't have to re-derive the same
 // chain on every call site. Prefer building your own Chain when the preset
 // doesn't fit; presets are starting points, not silver bullets.
+//
+// Every preset applies the layering documented in the package doc:
+// listed left to right, each arrow diagram below reads OUTERMOST to
+// innermost. In particular retry always sits INSIDE the circuit breaker,
+// so the breaker observes one outcome per logical call and a transient
+// failure that retry recovers from is recorded as a success — not as
+// MaxAttempts separate failures that could trip a healthy circuit. The
+// timeout is innermost, so it bounds each attempt rather than the whole
+// retry sequence.
 
 // HTTPClientConfig configures the HTTPClient preset.
 type HTTPClientConfig struct {
@@ -56,7 +65,7 @@ func (c *HTTPClientConfig) setDefaults() {
 
 // HTTPClient returns a preconfigured chain for outbound HTTP calls:
 //
-//	CircuitBreaker → Retry → Timeout → operation
+//	CircuitBreaker → Retry → Timeout → operation   (outermost → innermost)
 //
 // The breaker trips after CBFailureThreshold consecutive failures and stays
 // Open for CBOpenTimeout. Retry uses exponential backoff with jitter and
@@ -134,6 +143,7 @@ func (c *DatabaseQueryConfig) setDefaults() {
 // DatabaseQuery returns a chain tuned for database operations:
 //
 //	CircuitBreaker → Retry (rare, short backoff) → Timeout → operation
+//	(outermost → innermost)
 //
 // Retry is conservative because most database errors are non-transient.
 // The breaker trips later than HTTPClient because false-positive trips on
@@ -298,6 +308,7 @@ func (c *LLMCallConfig[T]) setDefaults() {
 // LLMCall returns a chain tuned for outbound LLM provider calls:
 //
 //	Bulkhead → CircuitBreaker → Retry → Budget → Timeout → operation
+//	(outermost → innermost)
 //
 // The budget sits inside Retry so every attempt is charged, capping the
 // total cost of a retry storm during a provider incident. The budget's
@@ -539,7 +550,12 @@ func llmIsRetryable(assumeIdempotent bool) func(error) bool {
 // RPCDownstream returns a chain tuned for RPC calls to a single downstream
 // service:
 //
-//	CircuitBreaker → Retry → Timeout → operation
+//	CircuitBreaker → Retry → Timeout → operation   (outermost → innermost)
+//
+// Retry is inside the breaker, so the breaker counts one outcome per
+// logical call; CBFailureThreshold is therefore a count of failed calls,
+// not of failed attempts, and does not need to be raised to compensate
+// for MaxRetries.
 //
 // Use one chain per downstream so the breaker and retry state are scoped
 // correctly. Sharing a single chain across multiple downstreams trips


### PR DESCRIPTION
Closes #67.

## What was wrong

Reproduced, and there is a second defect the issue did not know about.

**1. The rule was never stated.** The only statement about ordering was on
`Chain.Execute`: "Middlewares are applied in the order they were added to the
chain." That reads both ways. Establishing that first-added is *outermost*
required reading the right-to-left build loop in `chain.go`. As #67 says, the
failure is silent — the chain compiles, behaves correctly while the downstream is
healthy, and only misbehaves under load, with nothing pointing back at the line
that caused it.

**2. The two docs that did state an order contradicted each other.** Found while
verifying the claim:

| Source | Order |
| --- | --- |
| `docs/how-to-compose.md` | Bulkhead → RateLimit → **Timeout** → CircuitBreaker → Retry |
| `docs/concepts.md` | Bulkhead → RateLimit → CircuitBreaker → Retry → **Timeout** |
| All four presets (`presets.go:59,136,300,542`) | CircuitBreaker → Retry → **Timeout** |

So a reader following the how-to got a chain whose timeout bounds the *whole
retry sequence*, while the presets they were told to prefer bound *each attempt*.
`how-to-compose.md` was the outlier, against `concepts.md`, all four shipped
presets, and the expectation stated in #67 ("Timeout innermost — bounds each
attempt rather than the whole retry sequence"). Fixed in favour of the presets.

## What changed

Docs and tests only. No API or behaviour change.

**`middleware/chain.go`**
- Package doc: a "Layering order" section stating first-added is outermost, the
  canonical stack, and the retry/breaker consequence — including the issue's own
  `FailuresToTrip: 5` / `MaxAttempts: 3` worked example.
- `Chain.Execute`: the ambiguous sentence replaced with `A → B → C → fn → C → B → A`.
- Placement notes added to `WithCircuitBreaker`, `WithRetry`, `WithRateLimit`,
  `WithTimeout`, `WithBulkhead`. (`WithAdaptive`, `WithBudget`, `WithHedge`,
  `WithFallback` already had them — this closes the gap.)

**`docs/how-to-compose.md`** — new "The layering rule" section; recommended chain
corrected to timeout-innermost; per-step rationale rewritten to say *why* each
sits where it does; a new subsection on what timeout-innermost costs (worst case
becomes ~`MaxAttempts × timeout` + backoff, so use a parent deadline for a hard
ceiling) and what the alternative buys; the `FailuresToTrip <= MaxAttempts`
arithmetic added to the "retry outside CB" pitfall.

**`docs/concepts.md`** — "Composition order" now states the rule and the two
placements that surprise people.

**`middleware/presets.go`** — each arrow diagram marked outermost → innermost, as
the issue requested; a note on `RPCDownstream` that `CBFailureThreshold` counts
calls, not attempts, and so needs no compensation for `MaxRetries`.

**`middleware/layering_test.go`** (new file) — the rule is now executable, not
just prose:
- `TestChainLayeringOrder` records enter/exit around each layer and asserts
  `enter:first, enter:second, enter:third, operation, exit:third, exit:second,
  exit:first`. If the build loop in `Execute` is ever reversed, this fails
  instead of the docs quietly becoming wrong.
- `TestCanonicalStackLayering` builds the documented five-pattern stack and
  asserts the innermost timeout gives *each* attempt a live deadline, and that a
  recovered blip leaves the breaker Closed.

## On the suggested preset

I did not add `middleware.ExternalAPI[T]`. `HTTPClient`, `RPCDownstream` and
`LLMCall` already cover that shape; what was missing was the layering statement
in their docs, which this PR adds. Happy to add one if you'd still like it.

## Compatibility

**Backward compatible.** Comments, markdown, and one new test file — no exported
identifier, signature, or runtime behaviour touched. `klarlabs-studio/roady`
(v1.8.1) needs no changes; it does not import `fortify/middleware`.

## How verified

`go build ./...`, `go vet ./...`, `go test ./...` all pass.
`golangci-lint run ./middleware/...` reports 0 issues.

## Related

#69 is the companion behaviour change (retry's classification of
`ErrCircuitOpen`). Kept separate: that one changes runtime behaviour in `retry`
and deserves isolated review; this one is doc-only and also fixes the
independent timeout contradiction above. The wording here is deliberately
order-independent, so the two PRs can merge in either order.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D