### PR TITLE
feat(circuitbreaker): ship TripOnConsecutiveFailures and TripOnFailureRatio

### DIFF
--- a/circuitbreaker/breaker.go
+++ b/circuitbreaker/breaker.go
@@ -16,14 +16,27 @@
 //	    MaxRequests: 5,
 //	    Interval:    10 * time.Second,
 //	    Timeout:     60 * time.Second,
-//	    ReadyToTrip: func(counts circuitbreaker.Counts) bool {
-//	        return counts.ConsecutiveFailures > 5
-//	    },
+//	    ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(5),
 //	})
 //
 //	result, err := cb.Execute(ctx, func(ctx context.Context) (*Response, error) {
 //	    return callExternalAPI(ctx)
 //	})
+//
+// # Choosing a trip policy
+//
+// Two predicates cover the large majority of real ReadyToTrip
+// implementations, and both take plain ints so no uint32 conversion (and
+// no gosec G115 suppression) is needed at the call site:
+//
+//   - TripOnConsecutiveFailures(n) — opens after n failures in a row. Any
+//     success resets the streak, so this detects a downstream that is
+//     down, not one that is degraded.
+//   - TripOnFailureRatio(r, minRequests) — opens at a failure rate of r
+//     once minRequests have been recorded. This catches the partially
+//     failing downstream that consecutive counting misses.
+//
+// Callers needing something bespoke still receive the raw Counts.
 package circuitbreaker
 
 import (

--- a/circuitbreaker/config.go
+++ b/circuitbreaker/config.go
@@ -9,8 +9,17 @@ import (
 type Config struct {
 	// ReadyToTrip is called with a copy of Counts whenever a request fails in the Closed state.
 	// If ReadyToTrip returns true, the circuit breaker transitions from Closed to Open.
-	// If ReadyToTrip is nil, the circuit breaker uses a default function that returns true
-	// when the number of consecutive failures reaches 5.
+	// If ReadyToTrip is nil, the circuit breaker uses
+	// TripOnConsecutiveFailures(DefaultFailuresToTrip).
+	//
+	// Prefer the shipped predicates over a hand-written closure: they take
+	// an int threshold, so no uint32 conversion (and no gosec G115
+	// suppression) is needed at the call site.
+	//
+	//	ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(cfg.FailuresToTrip)
+	//	ReadyToTrip: circuitbreaker.TripOnFailureRatio(0.5, 20)
+	//
+	// Write your own when neither shape fits; Counts stays available.
 	ReadyToTrip func(counts Counts) bool
 
 	// OnStateChange is called whenever the state of the circuit breaker changes.
@@ -57,9 +66,7 @@ func (c *Config) setDefaults() {
 	}
 
 	if c.ReadyToTrip == nil {
-		c.ReadyToTrip = func(counts Counts) bool {
-			return counts.ConsecutiveFailures >= 5
-		}
+		c.ReadyToTrip = TripOnConsecutiveFailures(DefaultFailuresToTrip)
 	}
 
 	if c.IsSuccessful == nil {

--- a/circuitbreaker/example_test.go
+++ b/circuitbreaker/example_test.go
@@ -235,3 +235,53 @@ func Example_httpClient() {
 	fmt.Printf("HTTP status: %d\n", statusCode)
 	// Output: HTTP status: 200
 }
+
+// ExampleTripOnConsecutiveFailures shows the shipped predicate replacing a
+// hand-written ReadyToTrip. The threshold comes straight from application
+// config as an int, so there is no uint32 conversion at the call site and
+// nothing for gosec's G115 rule to flag.
+func ExampleTripOnConsecutiveFailures() {
+	// Threshold as it would arrive from config/flags — a plain int.
+	failuresToTrip := 3
+
+	cb := circuitbreaker.New[string](circuitbreaker.Config{
+		Timeout:     30 * time.Second,
+		ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(failuresToTrip),
+	})
+	defer func() { _ = cb.Close() }()
+
+	ctx := context.Background()
+	for i := 0; i < failuresToTrip; i++ {
+		_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+			return "", errors.New("downstream unavailable")
+		})
+	}
+
+	fmt.Printf("state after %d consecutive failures: %s\n", failuresToTrip, cb.State())
+	// Output: state after 3 consecutive failures: open
+}
+
+// ExampleTripOnFailureRatio shows the ratio predicate catching a downstream
+// that is degraded rather than dead. Consecutive counting cannot: every
+// failure here is followed by a success, so the streak never builds.
+func ExampleTripOnFailureRatio() {
+	cb := circuitbreaker.New[string](circuitbreaker.Config{
+		Timeout: 30 * time.Second,
+		// Trip at a 50% failure rate, but only once 6 requests are in.
+		ReadyToTrip: circuitbreaker.TripOnFailureRatio(0.5, 6),
+	})
+	defer func() { _ = cb.Close() }()
+
+	ctx := context.Background()
+	for i := 0; i < 4 && cb.State() == circuitbreaker.StateClosed; i++ {
+		_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+			return "", errors.New("downstream flaky")
+		})
+		_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+			return "ok", nil
+		})
+	}
+
+	fmt.Printf("state at a 50%% failure rate: %s\n", cb.State())
+	// Output: state at a 50% failure rate: open
+}

--- a/circuitbreaker/predicates.go
+++ b/circuitbreaker/predicates.go
@@ -1,0 +1,99 @@
+package circuitbreaker
+
+import "math"
+
+// DefaultFailuresToTrip is the consecutive-failure count used by the
+// breaker when Config.ReadyToTrip is nil.
+const DefaultFailuresToTrip = 5
+
+// TripOnConsecutiveFailures returns a ReadyToTrip predicate that opens the
+// circuit once n consecutive failures have been observed in the Closed
+// state. A single success resets the streak.
+//
+// This is the most common ReadyToTrip in practice, and shipping it spares
+// callers a conversion. A threshold held in application config is
+// naturally an int, while Counts.ConsecutiveFailures is a uint32, so the
+// hand-written form needs a narrowing cast:
+//
+//	ReadyToTrip: func(c circuitbreaker.Counts) bool {
+//	    return c.ConsecutiveFailures >= uint32(cfg.FailuresToTrip) // gosec G115
+//	}
+//
+// gosec reports that as G115 (integer overflow conversion int -> uint32),
+// so every consumer running gosec meets a finding on the most ordinary use
+// of this package, and the cheap fix — //nolint:gosec — builds the habit of
+// suppressing G115 in places where it is catching something real. Passing
+// an int here removes the cast and the suppression:
+//
+//	cb := circuitbreaker.New[T](circuitbreaker.Config{
+//	    ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(cfg.FailuresToTrip),
+//	})
+//
+// n is clamped to [1, math.MaxUint32]: values below 1 would trip the
+// breaker before any failure, and values above the counter's range would
+// otherwise wrap to a threshold far lower than intended.
+//
+// Consecutive counting cannot detect a downstream that fails only part of
+// the time, because any success resets the streak — a service failing 50%
+// of calls produces F S F F S F and never trips. Use TripOnFailureRatio
+// for that shape.
+func TripOnConsecutiveFailures(n int) func(Counts) bool {
+	threshold := clampToUint32(n)
+	return func(counts Counts) bool {
+		return counts.ConsecutiveFailures >= threshold
+	}
+}
+
+// TripOnFailureRatio returns a ReadyToTrip predicate that opens the circuit
+// when the failure ratio reaches r, once at least minRequests requests have
+// been recorded in the current counting window.
+//
+// Unlike TripOnConsecutiveFailures, this notices a downstream that is
+// degraded rather than dead: a service failing half its calls trips a
+// ratio predicate but never accumulates a consecutive-failure streak.
+//
+//	cb := circuitbreaker.New[T](circuitbreaker.Config{
+//	    Interval:    30 * time.Second,
+//	    ReadyToTrip: circuitbreaker.TripOnFailureRatio(0.5, 20),
+//	})
+//
+// minRequests keeps a cold breaker from opening on one unlucky request;
+// it is clamped to at least 1. r is clamped to [0, 1], with NaN treated as
+// 0. The comparison is inclusive, so r = 0.5 trips at exactly 50% and
+// r = 1 trips only when every recorded request failed.
+//
+// The window is the breaker's counting window, so this is a *tumbling*
+// window governed by Config.Interval, not a sliding one: counts reset
+// wholesale every Interval, and a burst that straddles a reset is split
+// into two sub-threshold halves. Choose Interval with that in mind.
+func TripOnFailureRatio(r float64, minRequests int) func(Counts) bool {
+	switch {
+	case math.IsNaN(r) || r < 0:
+		r = 0
+	case r > 1:
+		r = 1
+	}
+
+	minCalls := clampToUint32(minRequests)
+
+	return func(counts Counts) bool {
+		if counts.Requests < minCalls || counts.Requests == 0 {
+			return false
+		}
+		return float64(counts.TotalFailures)/float64(counts.Requests) >= r
+	}
+}
+
+// clampToUint32 maps an int threshold onto the range of the Counts
+// counters, guaranteeing at least 1 so a predicate cannot fire before any
+// request is recorded. Doing the narrowing here, once and provably in
+// range, is what lets callers pass a plain int.
+func clampToUint32(n int) uint32 {
+	if n < 1 {
+		return 1
+	}
+	if int64(n) > int64(math.MaxUint32) {
+		return math.MaxUint32
+	}
+	return uint32(n)
+}

--- a/circuitbreaker/predicates_test.go
+++ b/circuitbreaker/predicates_test.go
@@ -1,0 +1,281 @@
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestTripOnConsecutiveFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		n      int
+		counts Counts
+		want   bool
+	}{
+		{
+			name:   "below threshold does not trip",
+			n:      5,
+			counts: Counts{ConsecutiveFailures: 4},
+			want:   false,
+		},
+		{
+			name:   "at threshold trips",
+			n:      5,
+			counts: Counts{ConsecutiveFailures: 5},
+			want:   true,
+		},
+		{
+			name:   "above threshold trips",
+			n:      5,
+			counts: Counts{ConsecutiveFailures: 9},
+			want:   true,
+		},
+		{
+			name:   "zero is treated as one",
+			n:      0,
+			counts: Counts{ConsecutiveFailures: 1},
+			want:   true,
+		},
+		{
+			name:   "negative is treated as one",
+			n:      -7,
+			counts: Counts{ConsecutiveFailures: 1},
+			want:   true,
+		},
+		{
+			name:   "clamped threshold still needs a failure",
+			n:      -7,
+			counts: Counts{ConsecutiveFailures: 0},
+			want:   false,
+		},
+		{
+			name:   "threshold beyond uint32 clamps instead of wrapping",
+			n:      math.MaxUint32 + 100,
+			counts: Counts{ConsecutiveFailures: 1},
+			want:   false,
+		},
+		{
+			name:   "threshold beyond uint32 trips at the clamp",
+			n:      math.MaxUint32 + 100,
+			counts: Counts{ConsecutiveFailures: math.MaxUint32},
+			want:   true,
+		},
+		{
+			name:   "only consecutive failures matter, not totals",
+			n:      3,
+			counts: Counts{Requests: 100, TotalFailures: 50, ConsecutiveFailures: 2},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TripOnConsecutiveFailures(tt.n)(tt.counts); got != tt.want {
+				t.Errorf("TripOnConsecutiveFailures(%d)(%+v) = %v, want %v", tt.n, tt.counts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTripOnFailureRatio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		ratio       float64
+		minRequests int
+		counts      Counts
+		want        bool
+	}{
+		{
+			name:        "below minimum requests never trips",
+			ratio:       0.5,
+			minRequests: 20,
+			counts:      Counts{Requests: 19, TotalFailures: 19},
+			want:        false,
+		},
+		{
+			name:        "at minimum requests and above ratio trips",
+			ratio:       0.5,
+			minRequests: 20,
+			counts:      Counts{Requests: 20, TotalFailures: 11},
+			want:        true,
+		},
+		{
+			name:        "at minimum requests and exactly at ratio trips",
+			ratio:       0.5,
+			minRequests: 20,
+			counts:      Counts{Requests: 20, TotalFailures: 10},
+			want:        true,
+		},
+		{
+			name:        "below ratio does not trip",
+			ratio:       0.5,
+			minRequests: 20,
+			counts:      Counts{Requests: 20, TotalFailures: 9},
+			want:        false,
+		},
+		{
+			name:        "a half-failing downstream trips, unlike consecutive counting",
+			ratio:       0.5,
+			minRequests: 10,
+			counts:      Counts{Requests: 10, TotalFailures: 5, ConsecutiveFailures: 1},
+			want:        true,
+		},
+		{
+			name:        "ratio 1.0 requires every call to fail",
+			ratio:       1.0,
+			minRequests: 5,
+			counts:      Counts{Requests: 10, TotalFailures: 9},
+			want:        false,
+		},
+		{
+			name:        "ratio 1.0 trips at total failure",
+			ratio:       1.0,
+			minRequests: 5,
+			counts:      Counts{Requests: 10, TotalFailures: 10},
+			want:        true,
+		},
+		{
+			name:        "ratio above 1 clamps to 1",
+			ratio:       4.2,
+			minRequests: 5,
+			counts:      Counts{Requests: 10, TotalFailures: 10},
+			want:        true,
+		},
+		{
+			name:        "negative ratio clamps to 0 and trips on any failure",
+			ratio:       -0.5,
+			minRequests: 5,
+			counts:      Counts{Requests: 5, TotalFailures: 1},
+			want:        true,
+		},
+		{
+			name:        "NaN ratio clamps to 0",
+			ratio:       math.NaN(),
+			minRequests: 5,
+			counts:      Counts{Requests: 5, TotalFailures: 1},
+			want:        true,
+		},
+		{
+			name:        "minRequests below one is treated as one",
+			ratio:       0.5,
+			minRequests: 0,
+			counts:      Counts{Requests: 1, TotalFailures: 1},
+			want:        true,
+		},
+		{
+			name:        "negative minRequests is treated as one",
+			ratio:       0.5,
+			minRequests: -3,
+			counts:      Counts{Requests: 1, TotalFailures: 1},
+			want:        true,
+		},
+		{
+			name:        "zero requests never trips",
+			ratio:       0.5,
+			minRequests: 1,
+			counts:      Counts{},
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := TripOnFailureRatio(tt.ratio, tt.minRequests)(tt.counts)
+			if got != tt.want {
+				t.Errorf("TripOnFailureRatio(%v, %d)(%+v) = %v, want %v",
+					tt.ratio, tt.minRequests, tt.counts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTripPredicatesDriveTheBreaker wires the predicates through a real
+// breaker, so the tables above cannot drift from actual tripping behaviour.
+func TestTripPredicatesDriveTheBreaker(t *testing.T) {
+	t.Parallel()
+
+	failing := func(context.Context) (int, error) {
+		return 0, errors.New("downstream failed")
+	}
+	succeeding := func(context.Context) (int, error) {
+		return 1, nil
+	}
+
+	t.Run("consecutive failures", func(t *testing.T) {
+		t.Parallel()
+
+		cb := New[int](Config{
+			Timeout:     time.Minute,
+			ReadyToTrip: TripOnConsecutiveFailures(3),
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 2; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Fatalf("after 2 failures state = %s, want closed", got)
+		}
+
+		_, _ = cb.Execute(ctx, failing)
+		if got := cb.State(); got != StateOpen {
+			t.Errorf("after 3 failures state = %s, want open", got)
+		}
+	})
+
+	t.Run("a success resets consecutive counting", func(t *testing.T) {
+		t.Parallel()
+
+		cb := New[int](Config{
+			Timeout:     time.Minute,
+			ReadyToTrip: TripOnConsecutiveFailures(3),
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		_, _ = cb.Execute(ctx, failing)
+		_, _ = cb.Execute(ctx, failing)
+		_, _ = cb.Execute(ctx, succeeding)
+		_, _ = cb.Execute(ctx, failing)
+		_, _ = cb.Execute(ctx, failing)
+
+		if got := cb.State(); got != StateClosed {
+			t.Errorf("state = %s, want closed: the success reset the streak", got)
+		}
+	})
+
+	t.Run("failure ratio catches a partially failing downstream", func(t *testing.T) {
+		t.Parallel()
+
+		cb := New[int](Config{
+			Timeout:     time.Minute,
+			ReadyToTrip: TripOnFailureRatio(0.5, 6),
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		// Alternate failure/success: consecutive counting would never trip
+		// here, because every failure is followed by a success.
+		for i := 0; i < 4; i++ {
+			_, _ = cb.Execute(ctx, failing)
+			if cb.State() == StateOpen {
+				break
+			}
+			_, _ = cb.Execute(ctx, succeeding)
+		}
+
+		if got := cb.State(); got != StateOpen {
+			t.Errorf("state = %s, want open: a 50%% failure rate should trip a ratio predicate", got)
+		}
+	})
+}

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -45,9 +45,43 @@ Prevents cascading failures by temporarily stopping requests to a failing depend
 | `MaxRequests`   | Trial requests allowed in Half-Open before deciding the verdict.                         |
 | `Interval`      | Closed-state window for counting. Counts reset every `Interval`. Zero = never reset.     |
 | `Timeout`       | How long the breaker stays Open before transitioning to Half-Open. Default 60s.          |
-| `ReadyToTrip`   | Predicate called on each Closed-state failure; return `true` to trip Open.               |
+| `ReadyToTrip`   | Predicate called on each Closed-state failure; return `true` to trip Open. Defaults to `TripOnConsecutiveFailures(5)`. |
 | `IsSuccessful`  | Predicate that classifies an `error` as success/failure (e.g., treat `404` as success). |
 | `OnStateChange` | Async callback for transitions. Delivered in order via dispatcher goroutine.             |
+
+### Trip policies
+
+Two shipped predicates cover most `ReadyToTrip` implementations. Both take plain
+`int` thresholds, so a threshold read from application config needs no `uint32`
+conversion — and therefore no `//nolint:gosec` for
+[G115](https://gosec.io/rules/#g115) — at the call site:
+
+```go
+// Opens after 3 failures in a row. Any success resets the streak.
+ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(3)
+
+// Opens at a 50% failure rate, once at least 20 requests are recorded.
+ReadyToTrip: circuitbreaker.TripOnFailureRatio(0.5, 20)
+```
+
+Pick by failure shape:
+
+| Downstream behaviour | Consecutive | Ratio |
+| --- | --- | --- |
+| Hard down, every call fails | trips | trips |
+| Degraded, ~50% of calls fail | **never trips** — a success resets the streak | trips |
+| One-off blip | does not trip | does not trip (below `minRequests`) |
+
+`TripOnConsecutiveFailures` cannot see a partially failing downstream: a service
+returning `F S F F S F` never accumulates a streak, so the breaker stays Closed
+however long the degradation lasts. Reach for `TripOnFailureRatio` when
+"degraded but not dead" is a state you need to catch.
+
+Both evaluate over the breaker's counting window, which `Interval` resets
+wholesale — a *tumbling* window, not a sliding one. A burst straddling a reset is
+split into two sub-threshold halves.
+
+Callers needing something else still get the raw `Counts`.
 
 ### When to **not** use a circuit breaker
 


### PR DESCRIPTION
Closes #68.

## What was wrong

Reproduced, with gosec itself rather than by inspection. `Counts.ConsecutiveFailures`
is a `uint32`; a threshold in application config is naturally an `int`; so the
most common `ReadyToTrip` in existence needs a narrowing cast:

```go
ReadyToTrip: func(counts circuitbreaker.Counts) bool {
    return counts.ConsecutiveFailures >= uint32(cfg.FailuresToTrip)
},
```

```
[main.go:9] - G115 (CWE-190): integer overflow conversion int -> uint32
             (Confidence: MEDIUM, Severity: HIGH)
    8:  return func(counts Counts) bool {
  > 9:      return counts.ConsecutiveFailures >= uint32(c.FailuresToTrip)
   10:  }

Issues : 1
```

As #68 argues, the real cost is not the finding but the `//nolint:gosec` that
resolves it, and the habit that generalises to conversions where G115 is
catching something.

Note this repo's own `.golangci.yml` excludes G115 globally, so the friction is
invisible from inside fortify and lands entirely on consumers. `presets.go`
already sidesteps it by typing `CBFailureThreshold` as `uint32` — the same
pressure, worked around one preset at a time.

## Evidence it is fixed

Same consumer code, predicate substituted, same gosec invocation:

```
Files : 1   Lines : 25   Nosec : 0   Issues : 0
```

The narrowing now happens once inside `clampToUint32`, where the bounds are
provable, so gosec does not flag it there either.

(`circuitbreaker/breaker.go:117` still reports one G115 for `int32(cb.state)`.
That is pre-existing — confirmed by running gosec on unmodified `main` — and is
what the repo's own G115 exclusion is for. Out of scope here.)

## What changed

Additive. New file `circuitbreaker/predicates.go`:

```go
func TripOnConsecutiveFailures(n int) func(Counts) bool
func TripOnFailureRatio(r float64, minRequests int) func(Counts) bool
const DefaultFailuresToTrip = 5
```

- `TripOnConsecutiveFailures(n)` — `n` clamped to `[1, math.MaxUint32]`. Below 1
  would trip before any failure; above the counter range would otherwise wrap to
  a threshold far *lower* than intended, which is the exact bug G115 warns about.
- `TripOnFailureRatio(r, minRequests)` — `r` clamped to `[0, 1]` with NaN treated
  as 0; `minRequests` clamped to at least 1 so a cold breaker cannot open on one
  unlucky request. The comparison is inclusive (`>=`), matching Resilience4j's
  `failureRateThreshold`, so `r = 0.5` trips at exactly 50% and `r = 1` only at
  total failure.

`TripOnFailureRatio` also covers the shape consecutive counting cannot see at
all: a downstream failing half its calls produces `F S F F S F` and never
accumulates a streak. Both `ReadyToTrip` styles evaluate over the breaker's
counting window, which `Interval` resets wholesale — a *tumbling* window, not a
sliding one. That limitation is documented on the function and in
`docs/concepts.md`; #70 is the issue for sliding windows.

`Config.setDefaults` now expresses its default as
`TripOnConsecutiveFailures(DefaultFailuresToTrip)` rather than an inline closure.
Identical behaviour — the closure was `ConsecutiveFailures >= 5`.

Docs: `Config.ReadyToTrip`, the package doc's new "Choosing a trip policy"
section, a "Trip policies" section in `docs/concepts.md` with a
which-predicate-for-which-failure-shape table, and two runnable examples.

Tests: `predicates_test.go` — table-driven over both predicates including the
clamping edges (0, negative, `MaxUint32 + 100`, NaN), plus
`TestTripPredicatesDriveTheBreaker`, which wires them through a real breaker so
the tables cannot drift from actual tripping behaviour.

## On the alternative in the issue

I did not change `Counts` to `int` fields, despite breaking changes being
available for this release. It would churn every `ReadyToTrip` and `IsSuccessful`
predicate users have written, plus the `uint32` counters on
`ferrors.CircuitOpenError`, and would still leave the two predicates worth
shipping. The additive version is the better design here, not merely the safer
one.

## Compatibility

**Backward compatible.** `ReadyToTrip` keeps its signature, `Counts` keeps its
fields, hand-written predicates keep working, and the default's behaviour is
unchanged. Purely new exported identifiers.

`klarlabs-studio/roady` (v1.8.1) needs no changes; it imports only
`fortify/retry`, not `fortify/circuitbreaker`.

## How verified

`go build ./...`, `go vet ./...`, `go test ./...` pass.
`golangci-lint run ./circuitbreaker/...` reports 0 issues.
gosec before/after on a consumer reproduction, as above.

⚠️ **Unrelated pre-existing flake:** `TestProperty_OpenStateRejectsUntilTimeout`
fails intermittently under CPU contention — 2 failures in 24 runs on **unmodified
`main`**. It sets its own `ReadyToTrip`, so nothing here can affect it; its
`Timeout/2` margin is just too tight for a loaded scheduler. Flagged separately
so a red CI run on this PR is not mistaken for a real regression.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D