### PR TITLE
feat(circuitbreaker): add sliding-window failure-rate tripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Added
+
+- **circuitbreaker: sliding-window failure-rate tripping.** Consecutive-failure
+  counting only detects a downstream that is *down*; one that is merely degraded
+  never accumulates a streak, because any success resets it, so `F S F F S F`
+  leaves the circuit Closed however long the degradation lasts. `Interval` does
+  not rescue this — it is a *tumbling* window, so a burst spanning a reset is
+  split into two sub-threshold halves. `Config.SlidingWindowType`
+  (`SlidingWindowCount` / `SlidingWindowTime`), `SlidingWindowSize`,
+  `MinimumCalls` and `FailureRateThreshold` add the window both Resilience4j and
+  Polly default to: count-based keeps the last N outcomes in a circular buffer,
+  time-based the last N seconds in one-second buckets. `ReadyToTrip` still
+  overrides it, and setting both is logged when a `Logger` is configured
+  (#70).
+
 ### CI
 
 - Drop cross-platform matrix + redundant benchmark from every-push CI (#53)
-
-## [Unreleased]
 
 ## [1.7.0] - 2026-06-20
 

--- a/circuitbreaker/breaker.go
+++ b/circuitbreaker/breaker.go
@@ -37,6 +37,34 @@
 //     failing downstream that consecutive counting misses.
 //
 // Callers needing something bespoke still receive the raw Counts.
+//
+// # Sliding-window failure rate
+//
+// Consecutive-failure counting only detects a downstream that is down.
+// A downstream that is merely degraded — failing, say, half its calls —
+// never accumulates a streak, because any success resets it, so the
+// circuit stays Closed however long the degradation lasts. Config.Interval
+// does not help: it is a tumbling window, so a burst of failures spanning
+// a reset is split into two sub-threshold halves.
+//
+// Set Config.SlidingWindowType to trip on a failure rate over a sliding
+// window instead, as Resilience4j and Polly do by default:
+//
+//	cb := circuitbreaker.New[*Response](circuitbreaker.Config{
+//	    SlidingWindowType:    circuitbreaker.SlidingWindowCount,
+//	    SlidingWindowSize:    100, // last 100 calls
+//	    MinimumCalls:         20,  // ...but not before 20 are in
+//	    FailureRateThreshold: 0.5, // open at 50%
+//	})
+//
+// SlidingWindowCount aggregates the last SlidingWindowSize calls in a
+// circular buffer; SlidingWindowTime aggregates the last
+// SlidingWindowSize seconds in one-second buckets, and is the better
+// default for high-traffic services where a count window fills fast
+// enough to make the breaker jumpy. Neither has a boundary for a burst to
+// straddle.
+//
+// Config.ReadyToTrip overrides the sliding window when both are set.
 package circuitbreaker
 
 import (
@@ -92,6 +120,11 @@ type circuitBreaker[T any] struct {
 	generation    uint64
 	state         State
 
+	// window aggregates recent outcomes for failure-rate tripping. nil
+	// when no sliding window is configured, in which case tripping goes
+	// through config.ReadyToTrip. Guarded by mu.
+	window slidingWindow
+
 	// fastState/fastExpiry/fastGen mirror state/expiry/generation under
 	// atomic semantics. They allow beforeRequest to short-circuit when the
 	// breaker is in steady-state Closed without acquiring mu, restoring the
@@ -120,7 +153,18 @@ func (cb *circuitBreaker[T]) syncFastFields() {
 // New creates a new CircuitBreaker with the given configuration.
 // The circuit breaker starts in the Closed state.
 func New[T any](config Config) CircuitBreaker[T] {
+	// ReadyToTrip is the documented override, so note whether the caller
+	// supplied one before setDefaults populates it.
+	callerSetReadyToTrip := config.ReadyToTrip != nil
+
 	config.setDefaults()
+
+	usesWindow := !callerSetReadyToTrip && config.SlidingWindowType != SlidingWindowDisabled
+	if callerSetReadyToTrip && config.SlidingWindowType != SlidingWindowDisabled && config.Logger != nil {
+		config.Logger.Warn("circuit breaker: ReadyToTrip overrides the sliding-window configuration",
+			slog.String("sliding_window_type", config.SlidingWindowType.String()),
+		)
+	}
 
 	cb := &circuitBreaker[T]{
 		config:     config,
@@ -133,6 +177,10 @@ func New[T any](config Config) CircuitBreaker[T] {
 	cb.fastGen.Store(0)
 	cb.fastExpiry.Store(cb.expiry.UnixNano())
 	cb.fastState.Store(int32(StateClosed))
+
+	if usesWindow {
+		cb.window = newSlidingWindow(&config)
+	}
 
 	if config.OnStateChange != nil {
 		cb.stateChanges = make(chan stateChange, stateChangeBufferSize)
@@ -260,6 +308,9 @@ func (cb *circuitBreaker[T]) Reset() {
 	cb.state = StateClosed
 	cb.generation++
 	cb.counts.reset()
+	if cb.window != nil {
+		cb.window.reset()
+	}
 	cb.expiry = time.Now().Add(cb.config.Interval)
 	cb.syncFastFields()
 
@@ -352,6 +403,16 @@ func (cb *circuitBreaker[T]) onSuccess(state State, now time.Time) {
 	switch state {
 	case StateClosed:
 		cb.counts.onSuccess()
+		if cb.window != nil {
+			// Successes must enter the window too, or the failure rate
+			// has no denominator. Evaluating here as well as on failure
+			// matters only at the MinimumCalls boundary, where a success
+			// can be the call that makes the window eligible.
+			cb.window.record(true, now)
+			if cb.windowTrips(now) {
+				cb.setState(StateOpen, now)
+			}
+		}
 	case StateHalfOpen:
 		cb.counts.onSuccess()
 		if cb.counts.ConsecutiveSuccesses >= cb.config.MaxRequests {
@@ -366,6 +427,13 @@ func (cb *circuitBreaker[T]) onFailure(state State, now time.Time) {
 	switch state {
 	case StateClosed:
 		cb.counts.onFailure()
+		if cb.window != nil {
+			cb.window.record(false, now)
+			if cb.windowTrips(now) {
+				cb.setState(StateOpen, now)
+			}
+			return
+		}
 		if cb.config.ReadyToTrip(cb.counts) {
 			cb.setState(StateOpen, now)
 		}
@@ -385,6 +453,11 @@ func (cb *circuitBreaker[T]) setState(newState State, now time.Time) {
 	cb.state = newState
 	cb.generation++
 	cb.counts.reset()
+	// The window describes the previous regime; a breaker re-entering
+	// Closed after a trial should judge the downstream on fresh evidence.
+	if cb.window != nil {
+		cb.window.reset()
+	}
 
 	switch newState {
 	case StateClosed:

--- a/circuitbreaker/config.go
+++ b/circuitbreaker/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	//	ReadyToTrip: circuitbreaker.TripOnFailureRatio(0.5, 20)
 	//
 	// Write your own when neither shape fits; Counts stays available.
+	//
+	// Setting ReadyToTrip overrides the sliding-window fields below: it is
+	// the escape hatch for policies neither shape expresses. Configuring
+	// both is a mistake, and one that is logged when a Logger is set.
 	ReadyToTrip func(counts Counts) bool
 
 	// OnStateChange is called whenever the state of the circuit breaker changes.
@@ -48,6 +52,55 @@ type Config struct {
 	// when the circuit breaker is in the Half-Open state.
 	// If MaxRequests is 0, the circuit breaker allows only 1 request.
 	MaxRequests uint32
+
+	// SlidingWindowType enables failure-rate tripping over a sliding
+	// window and selects how outcomes are aggregated. The zero value,
+	// SlidingWindowDisabled, keeps the ReadyToTrip behaviour above.
+	//
+	// A sliding window is what Resilience4j and Polly default to, and it
+	// fixes two blind spots in consecutive counting:
+	//
+	//   - A downstream failing part of the time never accumulates a
+	//     consecutive-failure streak, because any success resets it. A
+	//     service failing half its calls can stay that way indefinitely
+	//     with the circuit closed.
+	//   - Interval is a tumbling window: it clears counts wholesale, so a
+	//     burst spanning a reset is split into two sub-threshold halves
+	//     and never trips. A sliding window has no boundary to straddle.
+	//
+	// It also decouples the trip threshold from retry's MaxAttempts. With
+	// consecutive counting and retry outside the breaker, one flaky call
+	// contributes up to MaxAttempts consecutive failures, so any
+	// threshold <= MaxAttempts opens the circuit on a single recovered
+	// blip. Two failures and a success inside a window of twenty is a 10%
+	// failure rate, nowhere near a sensible threshold.
+	SlidingWindowType SlidingWindowType
+
+	// SlidingWindowSize is the window's extent: a number of calls when
+	// SlidingWindowType is SlidingWindowCount, or a number of seconds
+	// when it is SlidingWindowTime.
+	//
+	// Defaults to DefaultCountWindowSize (100) or
+	// DefaultTimeWindowSeconds (60) respectively. Clamped to
+	// MaxSlidingWindowSize. Ignored when no sliding window is configured.
+	SlidingWindowSize int
+
+	// MinimumCalls is how many calls must be recorded in the window
+	// before the failure rate is evaluated, so a cold breaker cannot open
+	// on one unlucky request.
+	//
+	// Defaults to DefaultMinimumCalls (10). For a count-based window it
+	// is capped at SlidingWindowSize, since a larger value could never be
+	// reached and the breaker would silently never trip.
+	MinimumCalls int
+
+	// FailureRateThreshold is the failure ratio, in (0, 1], at which the
+	// circuit opens once MinimumCalls have been recorded. The comparison
+	// is inclusive, so 0.5 opens at exactly 50%.
+	//
+	// Defaults to DefaultFailureRateThreshold (0.5). Values outside
+	// (0, 1] fall back to the default.
+	FailureRateThreshold float64
 }
 
 // setDefaults applies default values to unset configuration fields
@@ -65,6 +118,11 @@ func (c *Config) setDefaults() {
 		c.Interval = 0
 	}
 
+	c.normalizeSlidingWindow()
+
+	// ReadyToTrip stays populated even when a sliding window is active,
+	// so the consecutive-failure path is never nil-dispatched; the
+	// breaker simply consults the window instead.
 	if c.ReadyToTrip == nil {
 		c.ReadyToTrip = TripOnConsecutiveFailures(DefaultFailuresToTrip)
 	}

--- a/circuitbreaker/example_test.go
+++ b/circuitbreaker/example_test.go
@@ -285,3 +285,31 @@ func ExampleTripOnFailureRatio() {
 	fmt.Printf("state at a 50%% failure rate: %s\n", cb.State())
 	// Output: state at a 50% failure rate: open
 }
+
+// Example_slidingWindowFailureRate shows failure-rate tripping over a
+// sliding window catching a downstream that is degraded rather than dead.
+// Consecutive-failure counting cannot: every failure below is followed by
+// a success, so no streak ever forms.
+func Example_slidingWindowFailureRate() {
+	cb := circuitbreaker.New[string](circuitbreaker.Config{
+		Timeout:              30 * time.Second,
+		SlidingWindowType:    circuitbreaker.SlidingWindowCount,
+		SlidingWindowSize:    20,  // aggregate the last 20 calls
+		MinimumCalls:         10,  // but wait for 10 before judging
+		FailureRateThreshold: 0.5, // open at a 50% failure rate
+	})
+	defer func() { _ = cb.Close() }()
+
+	ctx := context.Background()
+	for i := 0; i < 10 && cb.State() == circuitbreaker.StateClosed; i++ {
+		_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+			return "", errors.New("downstream degraded")
+		})
+		_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+			return "ok", nil
+		})
+	}
+
+	fmt.Printf("state at a 50%% failure rate: %s\n", cb.State())
+	// Output: state at a 50% failure rate: open
+}

--- a/circuitbreaker/window.go
+++ b/circuitbreaker/window.go
@@ -1,0 +1,248 @@
+package circuitbreaker
+
+import "time"
+
+// SlidingWindowType selects how the breaker aggregates outcomes when
+// failure-rate tripping is enabled. The zero value leaves the sliding
+// window off, so Config.ReadyToTrip governs tripping as before.
+type SlidingWindowType int
+
+const (
+	// SlidingWindowDisabled is the zero value: no sliding window. The
+	// breaker trips via Config.ReadyToTrip, which defaults to
+	// TripOnConsecutiveFailures(DefaultFailuresToTrip).
+	SlidingWindowDisabled SlidingWindowType = iota
+
+	// SlidingWindowCount aggregates the last SlidingWindowSize calls,
+	// as a circular buffer of outcomes. Equivalent to Resilience4j's
+	// COUNT_BASED window.
+	SlidingWindowCount
+
+	// SlidingWindowTime aggregates calls recorded in the last
+	// SlidingWindowSize seconds, in one-second buckets. Equivalent to
+	// Resilience4j's TIME_BASED window. Preferred for high-traffic
+	// services, where a count window fills fast enough to make the
+	// breaker jumpy.
+	SlidingWindowTime
+)
+
+// String returns the string representation of the SlidingWindowType.
+func (t SlidingWindowType) String() string {
+	switch t {
+	case SlidingWindowDisabled:
+		return "disabled"
+	case SlidingWindowCount:
+		return "count-based"
+	case SlidingWindowTime:
+		return "time-based"
+	default:
+		return "unknown"
+	}
+}
+
+// Sliding-window defaults, matching Resilience4j where it has an opinion.
+const (
+	// DefaultCountWindowSize is the number of calls aggregated when
+	// SlidingWindowCount is selected without a SlidingWindowSize.
+	DefaultCountWindowSize = 100
+
+	// DefaultTimeWindowSeconds is the number of seconds aggregated when
+	// SlidingWindowTime is selected without a SlidingWindowSize.
+	DefaultTimeWindowSeconds = 60
+
+	// DefaultMinimumCalls is the number of calls that must be recorded
+	// before a failure rate is evaluated, so a cold breaker cannot open
+	// on one unlucky request.
+	DefaultMinimumCalls = 10
+
+	// DefaultFailureRateThreshold is the failure ratio at which the
+	// circuit opens when none is configured.
+	DefaultFailureRateThreshold = 0.5
+
+	// MaxSlidingWindowSize bounds the window so a mistyped config cannot
+	// allocate an unreasonable buffer.
+	MaxSlidingWindowSize = 1_000_000
+)
+
+// slidingWindow aggregates recent call outcomes. Implementations are not
+// safe for concurrent use; the breaker calls them under its own mutex.
+type slidingWindow interface {
+	// record adds one outcome to the window.
+	record(success bool, now time.Time)
+	// stats returns the calls currently inside the window and how many
+	// of them failed.
+	stats(now time.Time) (calls, failures int)
+	// reset clears the window, discarding all recorded outcomes.
+	reset()
+}
+
+// newSlidingWindow builds the window described by cfg, or nil when no
+// sliding window is configured. cfg must already have been normalized.
+func newSlidingWindow(cfg *Config) slidingWindow {
+	switch cfg.SlidingWindowType {
+	case SlidingWindowCount:
+		return newCountWindow(cfg.SlidingWindowSize)
+	case SlidingWindowTime:
+		return newTimeWindow(cfg.SlidingWindowSize)
+	case SlidingWindowDisabled:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// countWindow keeps the last size outcomes in a circular buffer, so there
+// is no boundary for a burst of failures to straddle. Failures are
+// tracked incrementally, making both record and stats O(1).
+type countWindow struct {
+	outcomes []bool // true == failure
+	size     int
+	next     int
+	filled   int
+	failures int
+}
+
+func newCountWindow(size int) *countWindow {
+	return &countWindow{
+		outcomes: make([]bool, size),
+		size:     size,
+	}
+}
+
+func (w *countWindow) record(success bool, _ time.Time) {
+	if w.filled == w.size && w.outcomes[w.next] {
+		// Evicting a failure; drop it from the running total.
+		w.failures--
+	}
+	failure := !success
+	w.outcomes[w.next] = failure
+	if failure {
+		w.failures++
+	}
+	w.next = (w.next + 1) % w.size
+	if w.filled < w.size {
+		w.filled++
+	}
+}
+
+func (w *countWindow) stats(_ time.Time) (calls, failures int) {
+	return w.filled, w.failures
+}
+
+func (w *countWindow) reset() {
+	clear(w.outcomes)
+	w.next = 0
+	w.filled = 0
+	w.failures = 0
+}
+
+// timeBucket aggregates one second of outcomes. epoch identifies which
+// second, so a stale bucket is recognised and cleared rather than
+// double-counted when the ring wraps.
+type timeBucket struct {
+	epoch    int64
+	calls    int
+	failures int
+}
+
+// timeWindow keeps the last size seconds of outcomes as a ring of
+// one-second buckets (Resilience4j's partial aggregation). Buckets older
+// than the window are ignored by stats and overwritten by record, so
+// nothing is lost across a boundary the way a tumbling reset loses it.
+type timeWindow struct {
+	buckets []timeBucket
+	size    int
+}
+
+func newTimeWindow(sizeSeconds int) *timeWindow {
+	return &timeWindow{
+		buckets: make([]timeBucket, sizeSeconds),
+		size:    sizeSeconds,
+	}
+}
+
+// bucketFor returns the bucket owning now, clearing it first if it still
+// holds a previous lap around the ring.
+func (w *timeWindow) bucketFor(now time.Time) *timeBucket {
+	epoch := now.Unix()
+	idx := int(((epoch % int64(w.size)) + int64(w.size)) % int64(w.size))
+	b := &w.buckets[idx]
+	if b.epoch != epoch {
+		b.epoch = epoch
+		b.calls = 0
+		b.failures = 0
+	}
+	return b
+}
+
+func (w *timeWindow) record(success bool, now time.Time) {
+	b := w.bucketFor(now)
+	b.calls++
+	if !success {
+		b.failures++
+	}
+}
+
+func (w *timeWindow) stats(now time.Time) (calls, failures int) {
+	oldest := now.Unix() - int64(w.size) + 1
+	for i := range w.buckets {
+		b := &w.buckets[i]
+		if b.calls == 0 || b.epoch < oldest || b.epoch > now.Unix() {
+			continue
+		}
+		calls += b.calls
+		failures += b.failures
+	}
+	return calls, failures
+}
+
+func (w *timeWindow) reset() {
+	clear(w.buckets)
+}
+
+// normalizeSlidingWindow clamps the sliding-window fields to usable
+// values. It is a no-op when no sliding window is configured.
+func (c *Config) normalizeSlidingWindow() {
+	if c.SlidingWindowType == SlidingWindowDisabled {
+		return
+	}
+	if c.SlidingWindowType != SlidingWindowCount && c.SlidingWindowType != SlidingWindowTime {
+		c.SlidingWindowType = SlidingWindowDisabled
+		return
+	}
+
+	if c.SlidingWindowSize <= 0 {
+		if c.SlidingWindowType == SlidingWindowCount {
+			c.SlidingWindowSize = DefaultCountWindowSize
+		} else {
+			c.SlidingWindowSize = DefaultTimeWindowSeconds
+		}
+	}
+	if c.SlidingWindowSize > MaxSlidingWindowSize {
+		c.SlidingWindowSize = MaxSlidingWindowSize
+	}
+
+	if c.MinimumCalls <= 0 {
+		c.MinimumCalls = DefaultMinimumCalls
+	}
+	// A count window holds at most SlidingWindowSize outcomes, so a
+	// larger MinimumCalls could never be reached and the breaker would
+	// silently never trip.
+	if c.SlidingWindowType == SlidingWindowCount && c.MinimumCalls > c.SlidingWindowSize {
+		c.MinimumCalls = c.SlidingWindowSize
+	}
+
+	if c.FailureRateThreshold <= 0 || c.FailureRateThreshold > 1 {
+		c.FailureRateThreshold = DefaultFailureRateThreshold
+	}
+}
+
+// windowTrips reports whether the recorded window now justifies opening
+// the circuit. Must be called with cb.mu held.
+func (cb *circuitBreaker[T]) windowTrips(now time.Time) bool {
+	calls, failures := cb.window.stats(now)
+	if calls < cb.config.MinimumCalls {
+		return false
+	}
+	return float64(failures)/float64(calls) >= cb.config.FailureRateThreshold
+}

--- a/circuitbreaker/window_test.go
+++ b/circuitbreaker/window_test.go
@@ -1,0 +1,594 @@
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+var errDownstream = errors.New("downstream failed")
+
+func failing(context.Context) (int, error) { return 0, errDownstream }
+func succeeding(context.Context) (int, error) {
+	return 1, nil
+}
+
+// TestCountWindow covers the circular buffer directly, including the
+// eviction accounting that keeps stats O(1).
+func TestCountWindow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("counts outcomes until full", func(t *testing.T) {
+		t.Parallel()
+		w := newCountWindow(4)
+		now := time.Now()
+
+		w.record(false, now)
+		w.record(true, now)
+		w.record(false, now)
+
+		calls, failures := w.stats(now)
+		if calls != 3 || failures != 2 {
+			t.Errorf("stats = (%d, %d), want (3, 2)", calls, failures)
+		}
+	})
+
+	t.Run("evicts the oldest outcome once full", func(t *testing.T) {
+		t.Parallel()
+		w := newCountWindow(3)
+		now := time.Now()
+
+		// Fill with three failures.
+		for i := 0; i < 3; i++ {
+			w.record(false, now)
+		}
+		if calls, failures := w.stats(now); calls != 3 || failures != 3 {
+			t.Fatalf("stats = (%d, %d), want (3, 3)", calls, failures)
+		}
+
+		// Three successes push every failure out one at a time.
+		want := []int{2, 1, 0}
+		for i, wantFailures := range want {
+			w.record(true, now)
+			calls, failures := w.stats(now)
+			if calls != 3 {
+				t.Errorf("after success %d: calls = %d, want 3 (window stays full)", i+1, calls)
+			}
+			if failures != wantFailures {
+				t.Errorf("after success %d: failures = %d, want %d", i+1, failures, wantFailures)
+			}
+		}
+	})
+
+	t.Run("a burst spanning many laps is counted, not lost", func(t *testing.T) {
+		t.Parallel()
+		w := newCountWindow(10)
+		now := time.Now()
+
+		for i := 0; i < 100; i++ {
+			w.record(true, now)
+		}
+		for i := 0; i < 6; i++ {
+			w.record(false, now)
+		}
+
+		calls, failures := w.stats(now)
+		if calls != 10 || failures != 6 {
+			t.Errorf("stats = (%d, %d), want (10, 6)", calls, failures)
+		}
+	})
+
+	t.Run("reset clears everything", func(t *testing.T) {
+		t.Parallel()
+		w := newCountWindow(3)
+		now := time.Now()
+		w.record(false, now)
+		w.record(false, now)
+
+		w.reset()
+
+		if calls, failures := w.stats(now); calls != 0 || failures != 0 {
+			t.Errorf("stats after reset = (%d, %d), want (0, 0)", calls, failures)
+		}
+	})
+}
+
+// TestTimeWindow drives the bucket ring with an explicit clock, so the
+// eviction boundary is tested deterministically rather than by sleeping.
+func TestTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	base := time.Unix(1_700_000_000, 0)
+
+	t.Run("aggregates within the window", func(t *testing.T) {
+		t.Parallel()
+		w := newTimeWindow(5)
+
+		w.record(false, base)
+		w.record(true, base.Add(time.Second))
+		w.record(false, base.Add(2*time.Second))
+
+		calls, failures := w.stats(base.Add(2 * time.Second))
+		if calls != 3 || failures != 2 {
+			t.Errorf("stats = (%d, %d), want (3, 2)", calls, failures)
+		}
+	})
+
+	t.Run("drops buckets that fall out of the window", func(t *testing.T) {
+		t.Parallel()
+		w := newTimeWindow(3)
+
+		w.record(false, base)                   // t=0
+		w.record(false, base.Add(time.Second))  // t=1
+		w.record(true, base.Add(2*time.Second)) // t=2
+
+		if calls, failures := w.stats(base.Add(2 * time.Second)); calls != 3 || failures != 2 {
+			t.Fatalf("at t=2 stats = (%d, %d), want (3, 2)", calls, failures)
+		}
+
+		// At t=3 the window covers seconds 1..3, so t=0 has aged out.
+		if calls, failures := w.stats(base.Add(3 * time.Second)); calls != 2 || failures != 1 {
+			t.Errorf("at t=3 stats = (%d, %d), want (2, 1)", calls, failures)
+		}
+
+		// At t=5 nothing recorded remains.
+		if calls, failures := w.stats(base.Add(5 * time.Second)); calls != 0 || failures != 0 {
+			t.Errorf("at t=5 stats = (%d, %d), want (0, 0)", calls, failures)
+		}
+	})
+
+	t.Run("a stale bucket from a previous lap is not double counted", func(t *testing.T) {
+		t.Parallel()
+		w := newTimeWindow(3)
+
+		w.record(false, base) // lands in bucket 0 for second N
+
+		// Exactly one lap later the same bucket index is reused; the old
+		// content must be discarded, not added to.
+		later := base.Add(3 * time.Second)
+		w.record(false, later)
+
+		calls, failures := w.stats(later)
+		if calls != 1 || failures != 1 {
+			t.Errorf("stats = (%d, %d), want (1, 1)", calls, failures)
+		}
+	})
+
+	t.Run("reset clears everything", func(t *testing.T) {
+		t.Parallel()
+		w := newTimeWindow(3)
+		w.record(false, base)
+
+		w.reset()
+
+		if calls, failures := w.stats(base); calls != 0 || failures != 0 {
+			t.Errorf("stats after reset = (%d, %d), want (0, 0)", calls, failures)
+		}
+	})
+}
+
+func TestNormalizeSlidingWindow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Config
+		want Config
+	}{
+		{
+			name: "disabled is left alone",
+			in:   Config{},
+			want: Config{},
+		},
+		{
+			name: "count window gets count defaults",
+			in:   Config{SlidingWindowType: SlidingWindowCount},
+			want: Config{
+				SlidingWindowType:    SlidingWindowCount,
+				SlidingWindowSize:    DefaultCountWindowSize,
+				MinimumCalls:         DefaultMinimumCalls,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "time window gets time defaults",
+			in:   Config{SlidingWindowType: SlidingWindowTime},
+			want: Config{
+				SlidingWindowType:    SlidingWindowTime,
+				SlidingWindowSize:    DefaultTimeWindowSeconds,
+				MinimumCalls:         DefaultMinimumCalls,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "minimum calls cannot exceed a count window",
+			in: Config{
+				SlidingWindowType: SlidingWindowCount,
+				SlidingWindowSize: 5,
+				MinimumCalls:      50,
+			},
+			want: Config{
+				SlidingWindowType:    SlidingWindowCount,
+				SlidingWindowSize:    5,
+				MinimumCalls:         5,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "minimum calls may exceed a time window",
+			in: Config{
+				SlidingWindowType: SlidingWindowTime,
+				SlidingWindowSize: 5,
+				MinimumCalls:      50,
+			},
+			want: Config{
+				SlidingWindowType:    SlidingWindowTime,
+				SlidingWindowSize:    5,
+				MinimumCalls:         50,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "out-of-range threshold falls back to the default",
+			in: Config{
+				SlidingWindowType:    SlidingWindowCount,
+				SlidingWindowSize:    20,
+				MinimumCalls:         10,
+				FailureRateThreshold: 1.5,
+			},
+			want: Config{
+				SlidingWindowType:    SlidingWindowCount,
+				SlidingWindowSize:    20,
+				MinimumCalls:         10,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "oversized window is clamped",
+			in: Config{
+				SlidingWindowType: SlidingWindowCount,
+				SlidingWindowSize: MaxSlidingWindowSize * 4,
+				MinimumCalls:      10,
+			},
+			want: Config{
+				SlidingWindowType:    SlidingWindowCount,
+				SlidingWindowSize:    MaxSlidingWindowSize,
+				MinimumCalls:         10,
+				FailureRateThreshold: DefaultFailureRateThreshold,
+			},
+		},
+		{
+			name: "unknown window type disables the window",
+			in:   Config{SlidingWindowType: SlidingWindowType(99)},
+			want: Config{SlidingWindowType: SlidingWindowDisabled},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.in
+			got.normalizeSlidingWindow()
+
+			if got.SlidingWindowType != tt.want.SlidingWindowType ||
+				got.SlidingWindowSize != tt.want.SlidingWindowSize ||
+				got.MinimumCalls != tt.want.MinimumCalls ||
+				got.FailureRateThreshold != tt.want.FailureRateThreshold {
+				t.Errorf("normalized = {type:%v size:%d min:%d rate:%v}, want {type:%v size:%d min:%d rate:%v}",
+					got.SlidingWindowType, got.SlidingWindowSize, got.MinimumCalls, got.FailureRateThreshold,
+					tt.want.SlidingWindowType, tt.want.SlidingWindowSize, tt.want.MinimumCalls, tt.want.FailureRateThreshold)
+			}
+		})
+	}
+}
+
+// TestSlidingWindowTripsOnPartialFailure is the headline case from #70:
+// a downstream failing half its calls never accumulates a
+// consecutive-failure streak, so consecutive counting leaves the circuit
+// closed indefinitely while a rate window opens it.
+func TestSlidingWindowTripsOnPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	// F S F F S F S F F S — the sequence from the issue, repeated.
+	pattern := []bool{false, true, false, false, true, false, true, false, false, true}
+
+	run := func(t *testing.T, cfg Config) State {
+		t.Helper()
+		cb := New[int](cfg)
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for round := 0; round < 5; round++ {
+			for _, success := range pattern {
+				if success {
+					_, _ = cb.Execute(ctx, succeeding)
+				} else {
+					_, _ = cb.Execute(ctx, failing)
+				}
+				if cb.State() != StateClosed {
+					return cb.State()
+				}
+			}
+		}
+		return cb.State()
+	}
+
+	t.Run("consecutive counting never trips", func(t *testing.T) {
+		t.Parallel()
+		got := run(t, Config{
+			Timeout:     time.Minute,
+			ReadyToTrip: func(c Counts) bool { return c.ConsecutiveFailures >= 5 },
+		})
+		if got != StateClosed {
+			t.Errorf("state = %s, want closed: no streak of 5 ever forms in F S F F S F", got)
+		}
+	})
+
+	t.Run("count-based rate window trips", func(t *testing.T) {
+		t.Parallel()
+		got := run(t, Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         10,
+			FailureRateThreshold: 0.5,
+		})
+		if got != StateOpen {
+			t.Errorf("state = %s, want open: the window sees a 60%% failure rate", got)
+		}
+	})
+
+	t.Run("time-based rate window trips", func(t *testing.T) {
+		t.Parallel()
+		got := run(t, Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowTime,
+			SlidingWindowSize:    60,
+			MinimumCalls:         10,
+			FailureRateThreshold: 0.5,
+		})
+		if got != StateOpen {
+			t.Errorf("state = %s, want open: the window sees a 60%% failure rate", got)
+		}
+	})
+}
+
+func TestSlidingWindowMinimumCalls(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a cold breaker does not open on one unlucky request", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         10,
+			FailureRateThreshold: 0.5,
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		_, _ = cb.Execute(ctx, failing)
+
+		if got := cb.State(); got != StateClosed {
+			t.Errorf("state = %s, want closed: 1 call is below MinimumCalls", got)
+		}
+	})
+
+	t.Run("opens exactly when minimum calls is reached", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         6,
+			FailureRateThreshold: 1.0,
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 5; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Fatalf("after 5 failures state = %s, want closed (MinimumCalls is 6)", got)
+		}
+
+		_, _ = cb.Execute(ctx, failing)
+		if got := cb.State(); got != StateOpen {
+			t.Errorf("after 6 failures state = %s, want open", got)
+		}
+	})
+
+	t.Run("a success can be the call that makes the window eligible", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         4,
+			FailureRateThreshold: 0.5,
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Fatalf("after 3 failures state = %s, want closed", got)
+		}
+
+		// 3 failures of 4 calls is 75%, over the 50% threshold.
+		_, _ = cb.Execute(ctx, succeeding)
+		if got := cb.State(); got != StateOpen {
+			t.Errorf("state = %s, want open once the 4th call makes the window eligible", got)
+		}
+	})
+}
+
+// TestSlidingWindowDoesNotStraddleABoundary contrasts the sliding window
+// with Interval's tumbling reset, the second failure mode in #70.
+func TestSlidingWindowDoesNotStraddleABoundary(t *testing.T) {
+	t.Parallel()
+
+	const interval = 120 * time.Millisecond
+
+	// Six failures split evenly across a tumbling boundary: three before,
+	// three after. A threshold of 5 consecutive failures never sees more
+	// than 3, because Interval clears the counts in between.
+	burst := func(t *testing.T, cfg Config) State {
+		t.Helper()
+		cb := New[int](cfg)
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		time.Sleep(interval + 40*time.Millisecond) // cross the reset
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		return cb.State()
+	}
+
+	t.Run("tumbling interval loses the burst", func(t *testing.T) {
+		t.Parallel()
+		got := burst(t, Config{
+			Timeout:     time.Minute,
+			Interval:    interval,
+			ReadyToTrip: func(c Counts) bool { return c.ConsecutiveFailures >= 5 },
+		})
+		if got != StateClosed {
+			t.Errorf("state = %s, want closed: the reset splits 6 failures into 3 + 3", got)
+		}
+	})
+
+	t.Run("sliding window catches it", func(t *testing.T) {
+		t.Parallel()
+		got := burst(t, Config{
+			Timeout:              time.Minute,
+			Interval:             interval,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         5,
+			FailureRateThreshold: 0.5,
+		})
+		if got != StateOpen {
+			t.Errorf("state = %s, want open: a sliding window has no boundary to straddle", got)
+		}
+	})
+}
+
+func TestSlidingWindowPrecedenceAndLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ReadyToTrip overrides the window", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout: time.Minute,
+			// Would trip at 50% over 10 calls if it were consulted.
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         4,
+			FailureRateThreshold: 0.5,
+			// But an explicit predicate wins, and this one never trips.
+			ReadyToTrip: func(Counts) bool { return false },
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 20; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+
+		if got := cb.State(); got != StateClosed {
+			t.Errorf("state = %s, want closed: ReadyToTrip overrides the window", got)
+		}
+	})
+
+	t.Run("default config is unchanged by the new fields", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{Timeout: time.Minute})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 4; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Fatalf("after 4 failures state = %s, want closed (default trips at 5)", got)
+		}
+
+		_, _ = cb.Execute(ctx, failing)
+		if got := cb.State(); got != StateOpen {
+			t.Errorf("after 5 failures state = %s, want open", got)
+		}
+	})
+
+	t.Run("Reset clears the window", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout:              time.Minute,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         4,
+			FailureRateThreshold: 1.0,
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+
+		cb.Reset()
+
+		// Three more failures would have tripped it without the reset.
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Errorf("state = %s, want closed: Reset discarded the earlier failures", got)
+		}
+	})
+
+	t.Run("recovery through half-open starts from fresh evidence", func(t *testing.T) {
+		t.Parallel()
+		cb := New[int](Config{
+			Timeout:              50 * time.Millisecond,
+			MaxRequests:          1,
+			SlidingWindowType:    SlidingWindowCount,
+			SlidingWindowSize:    20,
+			MinimumCalls:         4,
+			FailureRateThreshold: 1.0,
+		})
+		defer func() { _ = cb.Close() }()
+
+		ctx := context.Background()
+		for i := 0; i < 4; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateOpen {
+			t.Fatalf("state = %s, want open", got)
+		}
+
+		time.Sleep(80 * time.Millisecond) // let it reach half-open
+		if _, err := cb.Execute(ctx, succeeding); err != nil {
+			t.Fatalf("trial request failed: %v", err)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Fatalf("state = %s, want closed after a successful trial", got)
+		}
+
+		// The pre-trip failures must not still be in the window.
+		for i := 0; i < 3; i++ {
+			_, _ = cb.Execute(ctx, failing)
+		}
+		if got := cb.State(); got != StateClosed {
+			t.Errorf("state = %s, want closed: the window was reset on recovery", got)
+		}
+	})
+}

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -40,7 +40,8 @@ A pragmatic comparison of Fortify against the most commonly used Go resilience l
 | Closed/Open/HalfOpen FSM      | Yes     | Yes       | Yes         |
 | Generics on result type       | Yes     | No        | Yes         |
 | Custom `IsSuccessful` predicate | Yes   | Yes       | Yes         |
-| Sliding-window counts         | No      | No        | Yes (count- and time-based) |
+| Sliding-window counts         | Yes (count- and time-based) | No | Yes (count- and time-based) |
+| Failure-rate threshold + minimum calls | Yes | No   | Yes         |
 | Lock-free fast path (steady-state Closed) | Yes  | No (RWMutex)  | n/a |
 | Structured error (state, retry-after, counts) | Yes (`*CircuitOpenError`) | No (sentinel only) | No |
 | OTel span attrs               | Yes (`otel/`) | No  | No        |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -83,6 +83,51 @@ split into two sub-threshold halves.
 
 Callers needing something else still get the raw `Counts`.
 
+### Sliding-window failure rate
+
+Both predicates above evaluate over that tumbling window. To count over a window
+with no boundary for a burst to straddle, and to have the rate judged for you
+rather than derived from `Counts`, set `SlidingWindowType` instead — as
+Resilience4j and
+Polly do by default:
+
+```go
+cb := circuitbreaker.New[Response](circuitbreaker.Config{
+    SlidingWindowType:    circuitbreaker.SlidingWindowCount,
+    SlidingWindowSize:    100, // last 100 calls
+    MinimumCalls:         20,  // ...but not before 20 are recorded
+    FailureRateThreshold: 0.5, // open at 50%
+})
+```
+
+| Field | Meaning | Default |
+| --- | --- | --- |
+| `SlidingWindowType` | `SlidingWindowCount`, `SlidingWindowTime`, or `SlidingWindowDisabled` (zero value) | disabled |
+| `SlidingWindowSize` | Calls (count-based) or seconds (time-based) | 100 / 60 |
+| `MinimumCalls` | Calls required before the rate is evaluated | 10 |
+| `FailureRateThreshold` | Ratio in `(0, 1]` at which to open; inclusive | 0.5 |
+
+- **`SlidingWindowCount`** — circular buffer of the last N outcomes. The smaller change, and right for most services.
+- **`SlidingWindowTime`** — the last N seconds in one-second buckets. Better for high-traffic services, where a count window fills fast enough to make the breaker jumpy.
+
+`MinimumCalls` stops a cold breaker opening on one unlucky request. For a
+count-based window it is capped at `SlidingWindowSize`, since a larger value
+could never be reached.
+
+`ReadyToTrip` **overrides** the sliding window when both are set; it remains the
+escape hatch for policies neither shape expresses. Setting both is logged as a
+warning when a `Logger` is configured.
+
+#### It also decouples the threshold from retry's `MaxAttempts`
+
+With consecutive counting and [retry outside the breaker](how-to-compose.md),
+one flaky call contributes up to `MaxAttempts` consecutive failures, so any
+`FailuresToTrip <= MaxAttempts` opens the circuit on a single recovered blip —
+`MaxAttempts: 3` with `FailuresToTrip: 2` trips on the first flaky call. Both
+values look reasonable in isolation, and the coupling is invisible. A rate window
+has no such interaction: two failures and a success inside a window of twenty is
+a 10% failure rate.
+
 ### When to **not** use a circuit breaker
 
 - The downstream is owned by you and idempotent — a bounded retry may be more appropriate.


### PR DESCRIPTION
Closes #70.

## What was wrong

All three failure modes reproduce, and each is now pinned by a test.

**1. A partially-failing downstream never trips.** `ConsecutiveFailures` resets to
0 on any success, so `F S F F S F` never reaches a threshold of 5. Half of all
requests fail indefinitely and the breaker, whose entire purpose is to notice
this, stays Closed. `TestSlidingWindowTripsOnPartialFailure/consecutive_counting_never_trips`
records exactly that.

**2. `Interval` is a tumbling window.** Six failures split 3-before / 3-after a
reset never form a streak of 5.
`TestSlidingWindowDoesNotStraddleABoundary/tumbling_interval_loses_the_burst`
pins it; the sibling subtest shows the sliding window catching the same burst.

**3. The coupling with retry outside the breaker.** Documented rather than
tested here (it belongs to the layering work in #67), but the arithmetic is in
`docs/concepts.md`: any `FailuresToTrip <= MaxAttempts` opens the circuit on one
recovered blip.

## What changed

Four additive `Config` fields, matching the shape the issue proposed and the
concepts Resilience4j and Polly share:

```go
SlidingWindowType    SlidingWindowType // count-based, time-based, or off (zero value)
SlidingWindowSize    int               // N calls, or N seconds
MinimumCalls         int               // rate not evaluated below this
FailureRateThreshold float64           // (0,1], inclusive comparison
```

**`circuitbreaker/window.go`** (new) — both aggregations behind a small internal
interface:

- `countWindow` — circular buffer of the last N outcomes. Failures are tracked
  incrementally on eviction, so `record` and `stats` are both O(1) rather than a
  scan of the buffer.
- `timeWindow` — ring of one-second buckets, each stamped with its epoch second,
  which is what lets a bucket reused a full lap later be recognised as stale and
  cleared instead of double-counted. This is Resilience4j's partial aggregation.

Defaults follow Resilience4j where it has an opinion: 100 calls / 60 seconds,
threshold 0.5, `MinimumCalls` 10. `MinimumCalls` is capped at `SlidingWindowSize`
for a count window — a larger value could never be reached, so the breaker would
silently never trip, which is the same class of bug the issue is about.

**Wiring.** Successes are recorded as well as failures (a rate needs a
denominator), and the rate is evaluated on both outcomes — the rate itself can
only fall on a success, but a success can be the call that pushes the window past
`MinimumCalls`. `TestSlidingWindowMinimumCalls/a_success_can_be_the_call_that_makes_the_window_eligible`
covers that boundary. The window is reset on every state transition and on
`Reset()`, so a breaker returning to Closed after a successful trial judges the
downstream on fresh evidence rather than the failures that tripped it.

**Precedence.** `ReadyToTrip` overrides the window when both are set, as the
issue specified, and remains the escape hatch. Setting both is a mistake, so it
is logged when a `Logger` is configured.

## Testing

`window_test.go` drives the aggregations directly with an explicit clock, so the
eviction boundaries are deterministic rather than slept through: the count
window's eviction accounting, the time window's ageing-out and stale-lap
handling, config normalization (table-driven over every clamp), and the
behavioural cases above.

Mutation-checked — each of these breaks tests:

| Mutation | Tests failing |
| --- | --- |
| `windowTrips` always returns false | 19 |
| `countWindow` skips eviction accounting | 8 |
| `timeWindow` ignores the stale-epoch check | 10 |

Also run under `-race`.

## Compatibility

**Backward compatible**, so no version consideration arises despite breaking
changes being permitted for this release — the additive design is simply the
right one here, since consecutive counting stays valid for "downstream is hard
down".

`SlidingWindowDisabled` is the zero value, so an existing `Config` literal
compiles and behaves identically: `TestSlidingWindowPrecedenceAndLifecycle/default_config_is_unchanged_by_the_new_fields`
asserts the default breaker still trips at exactly 5 consecutive failures. Only
new exported identifiers are added; `Counts`, `ReadyToTrip` and the FSM are
untouched.

`klarlabs-studio/roady` (v1.8.1) needs no changes; it imports only
`fortify/retry`.

`docs/COMPARISON.md` had "Sliding-window counts: **No**" for fortify against
failsafe-go's "Yes"; updated, since it would otherwise be wrong the moment this
merges.

## How verified

`go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./circuitbreaker/`.
`golangci-lint run ./circuitbreaker/...` reports 0 issues.

⚠️ **Two pre-existing flakes, unrelated to this PR** — flagged so a red CI run is
not mistaken for a regression. Both reproduce on a clean, unmodified `main`:
- `adaptive.TestGradient2_GrowsAtBaselineRTT` / `TestGradient2_ShrinksUnderRTTInflation`
  — full suite failed 1 run in 3 on stock `main`. `adaptive` has no fortify
  dependencies at all (`go list -deps` shows only itself), so nothing here can
  reach it.
- `circuitbreaker.TestProperty_OpenStateRejectsUntilTimeout` — 2 failures in 24
  runs on stock `main` under CPU contention; its `Timeout/2` margin is too tight
  for a loaded scheduler.

## Note for merging

#75 (issue #68, the trip predicates) also edits the `circuitbreaker` package doc
and the same section of `docs/concepts.md`. Whichever lands second will need a
trivial doc-comment rebase — no logic overlap: that PR adds `Counts`-based
predicates, this one adds window state alongside them. They compose: the
predicates remain the answer for consecutive counting, the window for rate.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D