### PR TITLE
fix(security): pymdown-extensions 11.0.0 -> 11.0.1 (GHSA-gm37-52c6-37mw)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.7
-pymdown-extensions==11.0.0
+pymdown-extensions==11.0.1


### PR DESCRIPTION
`ci / Security (nox)` is a **required check** and fails on every open PR with exactly one net-new high:

```
severity: high   rule: VULN-001   file: docs/requirements.txt:1
```

It blocks #72, #73, #74, #75 and #76 equally, and is caused by none of them.

## The pin was already meant to be patched

`45606b6` — *"fix(security): bump pymdown-extensions to a patched version (#63)"* — moved `10.21.3 → 11.0.0`.

**11.0.0 is the vulnerable version.** GHSA-gm37-52c6-37mw (exponential-backtracking ReDoS in the caret, tilde and betterem extensions) is fixed in **11.0.1**, so that bump landed one release short and the gate has been red since.

Fixed rather than baselined — waiving a required security gate to land feature work is the wrong trade when the gate is telling the truth.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D