### PR TITLE
fix: re-export the sentinels the docs name, and stop guessing Rate's unit silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`bulkhead.ErrBulkheadFull` and `circuitbreaker.ErrCircuitOpen`.** Both
+  packages' doc comments named these sentinels — *"Returns ErrBulkheadFull if
+  the request cannot be accommodated"* — while the values lived only in
+  `ferrors`, so the obvious line did not compile:
+
+  ```go
+  if errors.Is(err, bulkhead.ErrBulkheadFull) { // undefined
+  ```
+
+  A caller had to read the source to learn the sentinel was in `ferrors`, a
+  package they had no other reason to import. Both are now re-exported as the
+  *same value*, so `errors.Is` matches either spelling and existing
+  `ferrors`-based code is unaffected. `ratelimit` and `budget` already owned
+  their sentinel names; this makes the four packages consistent (#71).
+
+### Fixed
+
+- **`ratelimit` now says when it has guessed the unit.** `Rate` is read per
+  `Interval`, and an omitted `Interval` silently means per second. Writing
+  `Config{Rate: 50, Burst: 50}` for a 50-requests-per-minute provider quota
+  yields 50/second — sixty times the allowance — with no error and no warning,
+  making the limiter the cause of the 429s it was added to prevent. `New`
+  cannot return an error without breaking every caller, so the default stays;
+  it now logs a warning naming the effective rate and how to be explicit,
+  when a `Logger` is configured. Behaviour is unchanged (#66).
+
+  The same report claimed a 50 RPM quota could not be expressed at all. It
+  could: `Interval` has existed since the original token-bucket
+  implementation. The real defect was the silent default, which is what this
+  fixes.
+
 ## [1.9.0] - 2026-08-08
 
 First release since 1.8.1 (3 July) — a month of work, including one breaking

--- a/bulkhead/bulkhead.go
+++ b/bulkhead/bulkhead.go
@@ -29,6 +29,20 @@ import (
 	"go.klarlabs.de/fortify/ferrors"
 )
 
+// ErrBulkheadFull is returned when a request cannot be admitted: the worker
+// slots are full and either there is no queue or the queue is full too.
+//
+// It is the same value as ferrors.ErrBulkheadFull, re-exported here because
+// this package's own documentation names it. Without that, the obvious line
+// to write does not compile:
+//
+//	if errors.Is(err, bulkhead.ErrBulkheadFull) { ... }
+//
+// and a caller has to read the source to learn the sentinel lives in ferrors
+// — a package using bulkhead has no other reason to import. errors.Is against
+// either spelling matches, so existing ferrors-based code is unaffected.
+var ErrBulkheadFull = ferrors.ErrBulkheadFull
+
 // Bulkhead is a generic interface for enforcing concurrency limits.
 // It isolates operations to prevent resource exhaustion and provides queue overflow handling.
 type Bulkhead[T any] interface {

--- a/bulkhead/sentinel_test.go
+++ b/bulkhead/sentinel_test.go
@@ -1,0 +1,53 @@
+package bulkhead_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/fortify/bulkhead"
+	"go.klarlabs.de/fortify/ferrors"
+)
+
+// Execute's doc says "Returns ErrBulkheadFull if the request cannot be
+// accommodated". The obvious way to act on that must compile and must work
+// (#71) — previously `bulkhead.ErrBulkheadFull` was undefined, and a caller
+// had to read the source to discover the sentinel lived in ferrors, a package
+// they had no reason to import.
+func TestErrBulkheadFullIsMatchableFromThisPackage(t *testing.T) {
+	b := bulkhead.New[string](bulkhead.Config{MaxConcurrent: 1, MaxQueue: 0})
+
+	release := make(chan struct{})
+	occupied := make(chan struct{})
+	go func() {
+		_, _ = b.Execute(context.Background(), func(context.Context) (string, error) {
+			close(occupied)
+			<-release
+			return "held", nil
+		})
+	}()
+	<-occupied
+	defer close(release)
+
+	_, err := b.Execute(context.Background(), func(context.Context) (string, error) {
+		return "", nil
+	})
+	if err == nil {
+		t.Fatal("expected rejection while the only slot is held")
+	}
+
+	// The name the doc comment uses, in the package the doc comment is on.
+	if !errors.Is(err, bulkhead.ErrBulkheadFull) {
+		t.Errorf("errors.Is(err, bulkhead.ErrBulkheadFull) = false; err = %v", err)
+	}
+	// And it must remain the same sentinel, so existing ferrors-based
+	// matching keeps working.
+	if !errors.Is(err, ferrors.ErrBulkheadFull) {
+		t.Errorf("errors.Is(err, ferrors.ErrBulkheadFull) = false; the alias is not the same value")
+	}
+	if bulkhead.ErrBulkheadFull != ferrors.ErrBulkheadFull {
+		t.Error("bulkhead.ErrBulkheadFull must BE ferrors.ErrBulkheadFull, not a copy")
+	}
+	_ = time.Now
+}

--- a/circuitbreaker/breaker.go
+++ b/circuitbreaker/breaker.go
@@ -78,6 +78,15 @@ import (
 	"go.klarlabs.de/fortify/ferrors"
 )
 
+// ErrCircuitOpen is returned when the circuit is open and the call was
+// rejected without running.
+//
+// Same value as ferrors.ErrCircuitOpen, re-exported for the reason
+// bulkhead.ErrBulkheadFull is: Execute's documentation names it, so
+// errors.Is(err, circuitbreaker.ErrCircuitOpen) should compile. Matching on
+// either spelling works.
+var ErrCircuitOpen = ferrors.ErrCircuitOpen
+
 // CircuitBreaker is a generic interface for circuit breaker pattern implementation.
 // It protects against cascading failures by monitoring request outcomes and
 // temporarily blocking requests when a failure threshold is reached.

--- a/circuitbreaker/sentinel_test.go
+++ b/circuitbreaker/sentinel_test.go
@@ -1,0 +1,41 @@
+package circuitbreaker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.klarlabs.de/fortify/circuitbreaker"
+	"go.klarlabs.de/fortify/ferrors"
+)
+
+// Same defect as #71, one package over: Execute's doc says "it returns
+// ErrCircuitOpen", and circuitbreaker.ErrCircuitOpen did not exist.
+func TestErrCircuitOpenIsMatchableFromThisPackage(t *testing.T) {
+	cb := circuitbreaker.New[string](circuitbreaker.Config{
+		ReadyToTrip: circuitbreaker.TripOnConsecutiveFailures(1),
+	})
+	defer func() { _ = cb.Close() }()
+
+	ctx := context.Background()
+	_, _ = cb.Execute(ctx, func(context.Context) (string, error) {
+		return "", errors.New("down")
+	})
+
+	_, err := cb.Execute(ctx, func(context.Context) (string, error) {
+		return "should not run", nil
+	})
+	if err == nil {
+		t.Fatal("expected the open circuit to reject")
+	}
+
+	if !errors.Is(err, circuitbreaker.ErrCircuitOpen) {
+		t.Errorf("errors.Is(err, circuitbreaker.ErrCircuitOpen) = false; err = %v", err)
+	}
+	if !errors.Is(err, ferrors.ErrCircuitOpen) {
+		t.Errorf("errors.Is(err, ferrors.ErrCircuitOpen) = false; the alias is not the same value")
+	}
+	if circuitbreaker.ErrCircuitOpen != ferrors.ErrCircuitOpen {
+		t.Error("circuitbreaker.ErrCircuitOpen must BE ferrors.ErrCircuitOpen, not a copy")
+	}
+}

--- a/ratelimit/config.go
+++ b/ratelimit/config.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -174,6 +175,24 @@ func (c *Config) setDefaults() {
 
 	if c.Interval <= 0 {
 		c.Interval = time.Second
+		// Rate is meaningless without its unit, and the unit is invisible at
+		// the call site: Config{Rate: 50, Burst: 50} reads as "50" and means
+		// "50 per second". Someone expressing a 50-requests-per-minute
+		// provider quota that way gets sixty times their allowance, with no
+		// error and no warning — and the limiter becomes the cause of the
+		// 429s it was added to prevent (#66).
+		//
+		// New cannot return an error without breaking every caller, so the
+		// default stays. It does not have to be silent.
+		if c.Logger != nil {
+			c.Logger.Warn(
+				"ratelimit: Interval not set, defaulting to 1s — Rate is read per Interval",
+				"rate", c.Rate,
+				"interval", time.Second.String(),
+				"effective", fmt.Sprintf("%d per second", c.Rate),
+				"hint", "set Interval explicitly, e.g. Interval: time.Minute for a per-minute quota",
+			)
+		}
 	}
 	// Floor interval to prevent overflow in token calculations (HIGH-01)
 	if c.Interval < MinInterval {

--- a/ratelimit/interval_warning_test.go
+++ b/ratelimit/interval_warning_test.go
@@ -1,0 +1,88 @@
+package ratelimit_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"go.klarlabs.de/fortify/ratelimit"
+)
+
+// An omitted Interval silently means per-second. Someone writing
+//
+//	ratelimit.New(ratelimit.Config{Rate: 50, Burst: 50})
+//
+// for a 50-requests-per-minute provider quota gets 50/sec — sixty times over
+// — and the limiter itself causes the 429s it was added to prevent (#66).
+//
+// New cannot return an error without breaking every caller, so the default
+// stays. What it must not do is stay silent.
+func TestOmittedIntervalIsAnnounced(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ratelimit.Config
+		wantWarn bool
+	}{
+		{
+			name:     "omitted Interval warns",
+			config:   ratelimit.Config{Rate: 50, Burst: 50},
+			wantWarn: true,
+		},
+		{
+			// Explicit per-second is a deliberate choice, not a guess.
+			name:     "explicit Interval is silent",
+			config:   ratelimit.Config{Rate: 50, Burst: 50, Interval: time.Second},
+			wantWarn: false,
+		},
+		{
+			name:     "explicit per-minute is silent",
+			config:   ratelimit.Config{Rate: 50, Burst: 50, Interval: time.Minute},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			cfg := tc.config
+			cfg.Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+			rl := ratelimit.New(cfg)
+			defer func() { _ = rl.Close() }()
+
+			got := strings.Contains(buf.String(), "Interval")
+			if got != tc.wantWarn {
+				t.Errorf("warned=%v, want %v\nlog: %s", got, tc.wantWarn, buf.String())
+			}
+			if tc.wantWarn {
+				// The message has to say what it defaulted to and how to be
+				// explicit, or the reader learns nothing they didn't know.
+				for _, want := range []string{"1s", "Rate"} {
+					if !strings.Contains(buf.String(), want) {
+						t.Errorf("warning does not mention %q: %s", want, buf.String())
+					}
+				}
+			}
+		})
+	}
+}
+
+// The warning must not change behaviour.
+func TestOmittedIntervalStillDefaultsToPerSecond(t *testing.T) {
+	rl := ratelimit.New(ratelimit.Config{Rate: 3, Burst: 3})
+	defer func() { _ = rl.Close() }()
+
+	ctx := context.Background()
+	allowed := 0
+	for i := 0; i < 10; i++ {
+		if rl.Allow(ctx, "k") {
+			allowed++
+		}
+	}
+	if allowed != 3 {
+		t.Errorf("allowed %d, want 3; the warning changed behaviour", allowed)
+	}
+}


### PR DESCRIPTION
Closes #71 and #66. Two reports, one shape: **the library knew something the caller could not see.**

## #71 — a doc comment naming an identifier that doesn't exist

`bulkhead.Execute`:

> Returns `ErrBulkheadFull` if the request cannot be accommodated.

```go
if errors.Is(err, bulkhead.ErrBulkheadFull) { // undefined: bulkhead.ErrBulkheadFull
```

The value lives in `ferrors` — a package someone using `bulkhead` has no other reason to import — and the comment never says so, so the reader has to go to the source.

**`circuitbreaker` had the identical defect one package over.** `Execute`'s doc names `ErrCircuitOpen`; that was also only in `ferrors`. I checked all nine pattern packages rather than fixing the reported one: `timeout` and `streamtimeout` already qualify theirs correctly, and `ratelimit` and `budget` already own their sentinel names. Fixing both leaves the convention consistent instead of half-applied.

Both re-exported as **the same value**, not copies — `errors.Is` matches either spelling, existing `ferrors`-based code is untouched, and the tests assert identity rather than just matching.

## #66 — the reported problem isn't real; the one underneath it is

> `Rate` is interpreted as requests per second. A 50 RPM quota is 0.833 requests/sec, which cannot be expressed.

It can. `Interval` has existed since the original token-bucket implementation, long before the report:

```go
ratelimit.New(ratelimit.Config{Rate: 50, Interval: time.Minute, Burst: 50})
```

Verified, not asserted: a burst of 60 against that config allows exactly **50**.

**But the reporter's secondary point is the real bug, and worse than they framed it:**

```go
if c.Interval <= 0 {
    c.Interval = time.Second
}
```

An omitted `Interval` **silently** means per-second. `Config{Rate: 50, Burst: 50}` intending a 50 RPM quota gives sixty times the allowance — no error, no warning — and the limiter becomes the cause of the 429s it was added to prevent. That is precisely the consequence they predicted; they diagnosed it as a type limitation when it's a silent default.

`New` can't return an error without breaking every caller, so the default stays and is now **announced**: a warning naming the effective rate and how to be explicit, when a `Logger` is configured.

```
level=WARN msg="ratelimit: Interval not set, defaulting to 1s — Rate is read per Interval"
  rate=50 interval=1s effective="50 per second"
  hint="set Interval explicitly, e.g. Interval: time.Minute for a per-minute quota"
```

A test asserts behaviour is **unchanged** — a warning that quietly altered the limit would be a worse bug than the one being fixed.

#72 documented this in v1.9.0, which makes it findable. That's necessary and not sufficient: a default that silently means per-second is still a trap for anyone who doesn't read the field docs first.

## Verification

Both sentinel tests fail to compile before the change (`undefined: bulkhead.ErrBulkheadFull`, `undefined: circuitbreaker.ErrCircuitOpen`) and pass after. The interval tests cover omitted, explicit-second and explicit-minute, plus a behaviour-unchanged check. Full suite green.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D