### PR TITLE
fix(ci): let the weekly changelog PR pass its own required checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -48,6 +48,16 @@ jobs:
       - name: Open PR with the refreshed digest
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          # A PR opened with the default GITHUB_TOKEN does not trigger
+          # workflows — GitHub blocks that to prevent a job from recursively
+          # triggering itself. main requires four status checks, so the weekly
+          # PR arrived with none of them reported and could never merge: a bot
+          # opening an unmergeable PR every Monday, indefinitely.
+          #
+          # NOX_TOKEN is a PAT, so its PR triggers CI like any other and the
+          # required checks actually report. Falls back to GITHUB_TOKEN, which
+          # still opens the PR — it just needs an admin merge.
+          token: ${{ secrets.NOX_TOKEN || github.token }}
           commit-message: "chore(changelog): refresh the generated commit digest"
           title: "chore(changelog): refresh the generated commit digest"
           body: |


### PR DESCRIPTION
**#81 has no status checks at all and is `BLOCKED`.** It is not a flake and not a one-off — a new unmergeable sibling would arrive every Monday.

## Cause

A PR opened with the default `GITHUB_TOKEN` **does not trigger workflows**. GitHub blocks that deliberately, so a job cannot recursively trigger itself. `main` requires four status checks:

```
ci / Lint    ci / Test (ubuntu-latest)    ci / Build    ci / Security (nox)
```

None of them ever report on a bot-authored PR, so the merge button can never turn green. The workflow was doing its job correctly and producing something unmergeable.

## Not the trap it looks like

This resembles the `paths-ignore` + required-checks deadlock, and it isn't. **#62 already fixed that**: the filter now applies only to `push`, so a human opening a docs-only PR does get CI. Verified before changing anything — the `pull_request` trigger has no path filter. The distinguishing fact is the bot identity, not the file types.

## Fix

`NOX_TOKEN` is an org secret and already a PAT, so a PR opened with it triggers CI like any other. Falls back to `github.token`, which still opens the PR — it just needs an admin merge, which is the state today rather than a regression.

## On #81 itself

Worth noting it is otherwise exactly right: it touches **only `git-cliff/CHANGELOG.md`** and leaves the hand-written `CHANGELOG.md` alone. That is the guard from #78 working — before it, this job appended a duplicate `## [Unreleased]` heading to the real changelog every week. I will admin-merge #81, since it predates this fix.

https://claude.ai/code/session_01CKxbiYE7cJ4PBbsBjarX6D